### PR TITLE
chore: Unify pnpm version to 10.13.1 across all configurations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 10.13.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,9 @@ FROM node:22-alpine AS build
 # Set working directory
 WORKDIR /app
 
-# Install pnpm version 10
 # Enable corepack and activate pnpm
 RUN corepack enable
-RUN corepack prepare pnpm@10 --activate
+RUN corepack prepare pnpm@10.13.1 --activate
 
 # Copy package.json and pnpm-lock.yaml
 COPY package.json pnpm-lock.yaml ./
@@ -34,7 +33,7 @@ WORKDIR /app
 
 # Enable corepack and activate pnpm in production stage
 RUN corepack enable
-RUN corepack prepare pnpm@10 --activate
+RUN corepack prepare pnpm@10.13.1 --activate
 
 # Copy the built output from the build stage
 COPY --from=build /app/.output ./.output

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "engines": {
     "node": "~22",
-    "pnpm": "~10"
+    "pnpm": "~10.13.1"
   },
   "scripts": {
     "build": "nuxt build",


### PR DESCRIPTION
Standardizes the pnpm package manager version to 10.13.1 across all project configurations to prevent version inconsistencies between development, CI/CD, and production environments.

**Specifically, it addresses and includes the following:**

- Updated pnpm version in `package.json` engines from `~10` to `~10.13.1`
- Updated pnpm version in GitHub Actions workflow from `10` to `10.13.1`
- Updated pnpm version in Dockerfile build stage from `pnpm@10` to `pnpm@10.13.1`
- Updated pnpm version in Dockerfile production stage from `pnpm@10` to `pnpm@10.13.1`
- Removed outdated comment in Dockerfile regarding pnpm installation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Standardized the package manager to pnpm 10.13.1 across CI, container builds, and production activation for consistent, reproducible installs.
  * Updated engine constraints to align with the new pnpm version requirement.
  * General workflow maintenance with no changes to application behavior.
  * This reduces version drift between environments and mitigates install-time discrepancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->