### PR TITLE
fix: Remove explicit pnpm version from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.13.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Removes the explicit pnpm version specification from the release workflow, allowing the workflow to automatically use the version defined in package.json's packageManager field.

**Specifically, it addresses and includes the following:**

- Removed hardcoded pnpm version 10.13.1 from .github/workflows/release.yml
- Workflow now uses pnpm version from package.json packageManager field
- Simplified workflow configuration by removing redundant version specification
- Improves maintainability by having single source of truth for pnpm version
