### PR TITLE
fix: release-please-action publisher & workflow setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,21 +15,9 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-
       - name: Release Please Action
         id: release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node


### PR DESCRIPTION
Fixes the release workflow by updating the release-please-action to use the correct `googleapis` publisher and streamlines the workflow by removing unnecessary setup steps.

**Specifically, it addresses and includes the following:**

- Changed release-please-action from `google-github-actions/release-please-action@v4` to `googleapis/release-please-action@v4`
- Removed redundant checkout step (not needed for release-please action)
- Removed pnpm setup step (not required at this stage)
- Removed Node.js setup step (not required at this stage)
- Simplified workflow configuration by keeping only the necessary release-please action step


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated release automation to use the latest Release Please action, simplifying the workflow by removing redundant setup steps.
  * No impact to application features or behavior; release and publishing processes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->