### PR TITLE
feat: Add core view mode to results page with customization params

### DIFF
--- a/app/components/ui/UiInput.vue
+++ b/app/components/ui/UiInput.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
-defineProps({
+const props = defineProps({
   modelValue: {
-    type: String,
+    type: [String, Number],
     required: true
   },
   type: {
     type: String,
     default: 'text'
+  },
+  step: {
+    type: [String, Number],
+    default: '1'
   },
   placeholder: {
     type: String,
@@ -19,17 +23,24 @@ defineProps({
 })
 
 const emit = defineEmits<{
-  'update:modelValue': [value: string]
+  'update:modelValue': [value: string | number]
 }>()
 
 function onInput(event: Event) {
-  emit('update:modelValue', (event.target as HTMLInputElement).value)
+  const target = event.target as HTMLInputElement
+  if (props.type === 'number') {
+    emit('update:modelValue', target.valueAsNumber)
+  }
+  else {
+    emit('update:modelValue', target.value)
+  }
 }
 </script>
 
 <template>
   <input
     :type="type"
+    :step="step"
     :placeholder="placeholder"
     :value="modelValue"
     :required="required"

--- a/app/components/ui/UiSection.vue
+++ b/app/components/ui/UiSection.vue
@@ -1,5 +1,14 @@
+<script setup lang="ts">
+defineProps({
+  bare: {
+    type: Boolean,
+    default: false
+  }
+})
+</script>
+
 <template>
-  <section class="bg-white border-[3px] border-black p-8">
+  <section :class="{ 'bg-white border-[3px] border-black p-8' : !bare }">
     <slot />
   </section>
 </template>

--- a/app/pages/results.vue
+++ b/app/pages/results.vue
@@ -13,6 +13,7 @@ const isCoreView = computed(() => route.query.core !== undefined)
 // State for core view parameters
 const padding = ref(route.query.padding ? Number(route.query.padding) : 0)
 const scale = ref(route.query.scale ? Number(route.query.scale) : 1)
+const hideResults = ref(route.query.hideResults !== undefined)
 
 // Add body class for core view
 useHead({
@@ -37,7 +38,8 @@ async function goToCoreView() {
   const query = {
     core: '',
     padding: padding.value,
-    scale: scale.value
+    scale: scale.value,
+    hideResults: hideResults.value ? '' : undefined
   }
   await navigateTo({ path: '/results', query })
 }
@@ -108,10 +110,18 @@ function getPercentage(count: number) {
         >
           <div class="flex justify-between items-center text-lg">
             <span class="font-bold">{{ option }}</span>
-            <span class="py-1 px-2.5 bg-gray-100 border-2 border-black text-sm">{{ count }} votes</span>
+            <span class="py-1 px-2.5 bg-gray-100 border-2 border-black text-sm">
+              <template v-if="hideResults">?</template>
+              <template v-else>{{ count }}</template>
+              votes
+            </span>
           </div>
           <div class="h-12 bg-gray-100 border-[3px] border-black relative overflow-hidden">
+            <div v-if="hideResults" class="flex items-center justify-center h-full">
+              <span class="text-2xl font-bold text-gray-400">?</span>
+            </div>
             <div
+              v-else
               class="h-full bg-black transition-width duration-500 ease-out flex items-center justify-end pr-2.5 min-w-[50px] relative result-bar"
               :style="{ width: getBarWidth(count) + '%' }"
             >
@@ -159,6 +169,10 @@ function getPercentage(count: number) {
             <label for="scale" class="text-sm font-bold">Scale</label>
             <UiInput id="scale" v-model="scale" type="number" step="0.1" placeholder="e.g., 1.0" />
           </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <input id="hideResults" v-model="hideResults" type="checkbox" class="w-4 h-4">
+          <label for="hideResults" class="text-sm font-bold">Hide Results</label>
         </div>
         <UiButton @click="goToCoreView">
           Generate Core View

--- a/app/pages/results.vue
+++ b/app/pages/results.vue
@@ -7,6 +7,16 @@ definePageMeta({
 
 const { results } = useQuizSocket()
 
+const route = useRoute()
+const isCoreView = computed(() => route.query.core !== undefined)
+
+// Add body class for core view
+useHead({
+  bodyAttrs: {
+    class: isCoreView.value ? 'core-view-body' : ''
+  }
+})
+
 // Fetch initial results
 const { data: fetchedResults, refresh: refreshResults } = await useFetch<Results>('/api/results/current')
 
@@ -45,10 +55,10 @@ function getPercentage(count: number) {
 </script>
 
 <template>
-  <div class="max-w-4xl mx-auto p-5 min-h-screen">
-    <UiPageTitle class="relative page-title">Live Results</UiPageTitle>
+  <div :class="{ 'max-w-4xl mx-auto p-5 min-h-screen': !isCoreView }">
+    <UiPageTitle v-if="!isCoreView" class="relative page-title">Live Results</UiPageTitle>
 
-    <UiSection v-if="results" class="border-[5px]">
+    <UiSection v-if="results" :bare="isCoreView">
       <!-- Question Display -->
       <div class="mb-10 border-b-[3px] border-black pb-5">
         <h2 class="text-3xl mb-4 leading-tight">{{ results.question.question_text }}</h2>
@@ -87,7 +97,7 @@ function getPercentage(count: number) {
     </UiSection>
 
     <!-- No Active Question -->
-    <UiSection v-else class="border-[5px] py-20 px-8 text-center">
+    <UiSection v-else :bare="isCoreView" :class="{ 'py-20 px-8 text-center': !isCoreView }">
       <h2 class="text-3xl mb-4">No Active Question</h2>
       <p class="text-xl mb-8">Waiting for a question to be published...</p>
       <div class="flex justify-center gap-2.5">
@@ -98,7 +108,7 @@ function getPercentage(count: number) {
     </UiSection>
 
     <!-- Navigation -->
-    <div class="flex justify-center gap-5 mt-8">
+    <div v-if="!isCoreView" class="flex justify-center gap-5 mt-8">
       <UiButton @click="refreshResults" variant="link">
         Refresh
       </UiButton>
@@ -107,9 +117,24 @@ function getPercentage(count: number) {
           ← Back to Quiz
         </UiButton>
       </NuxtLink>
+      <NuxtLink to="/results?core">
+        <UiButton variant="link">
+          Core View
+        </UiButton>
+      </NuxtLink>
     </div>
   </div>
 </template>
+
+<style>
+  .core-view-body {
+    @apply bg-white;
+  }
+
+  .core-view-body::before {
+    content: none;
+  }
+</style>
 
 <style scoped>
 .page-title::after {


### PR DESCRIPTION
Adds a core view mode to the results page that provides a minimal, embeddable version of the results display. The core view removes all navigation and layout elements, showing only the question and results content. The implementation includes a generator form with parameters for padding, scale, and result visibility.

**Specifically, it addresses and includes the following:**

- Core view mode activated via URL query parameter `?core`
- Padding parameter for adjustable content spacing
- Scale parameter for dynamic content sizing
- Hide results parameter to mask actual vote counts with question marks
- Core view generator form with parameter controls
- Enhanced UiSection component with bare prop for borderless rendering
- Updated UiInput component with number type support and step attribute
- Body class styling for core view mode
- Dynamic style computation based on URL parameters

