### PR TITLE
feat: Add startup process for importing questions

### DIFF
--- a/app/types.ts
+++ b/app/types.ts
@@ -5,6 +5,8 @@ export interface Question {
   is_locked: boolean
 }
 
+export type InputQuestion = Omit<Question, 'id' | 'is_locked'>
+
 export interface Answer {
   id: string
   question_id: string

--- a/server/utils/storage.ts
+++ b/server/utils/storage.ts
@@ -71,13 +71,17 @@ async function initStorage(event?: H3Event) {
           const existingQuestions: Question[] = JSON.parse(questionsData)
           const existingQuestionTexts = new Set(existingQuestions.map(q => q.question_text))
 
-          const newQuestions: Question[] = predefinedQuestions
-            .filter(q => !existingQuestionTexts.has(q.question_text))
-            .map(q => ({
-              ...q,
-              id: createId(),
-              is_locked: false
-            }))
+          const newQuestions: Question[] = []
+          for (const q of predefinedQuestions) {
+            if (!existingQuestionTexts.has(q.question_text)) {
+              existingQuestionTexts.add(q.question_text) // Add to set to prevent duplicates within the batch
+              newQuestions.push({
+                ...q,
+                id: createId(),
+                is_locked: false
+              })
+            }
+          }
 
           if (newQuestions.length > 0) {
             const allQuestions = [...existingQuestions, ...newQuestions]

--- a/server/utils/storage.ts
+++ b/server/utils/storage.ts
@@ -31,7 +31,32 @@ async function initStorage(event?: H3Event) {
     // Process predefined questions
     try {
       const predefinedData = await fs.readFile(PREDEFINED_QUESTIONS_FILE, 'utf-8')
-      const predefinedQuestions: InputQuestion[] = JSON.parse(predefinedData)
+      let predefinedQuestions: InputQuestion[]
+
+      try {
+        predefinedQuestions = JSON.parse(predefinedData)
+      }
+      catch (parseError: unknown) {
+        logger_error('Malformed JSON in predefined-questions.json:', parseError)
+        return // Stop processing if JSON is invalid
+      }
+
+      if (!Array.isArray(predefinedQuestions)) {
+        logger_error('Predefined questions file must contain a JSON array.')
+        return
+      }
+
+      // Validate each question object
+      for (const q of predefinedQuestions) {
+        if (typeof q.question_text !== 'string' || q.question_text.trim() === '') {
+          logger_error('Invalid question_text in predefined question:', q)
+          return // Stop processing
+        }
+        if (!Array.isArray(q.answer_options) || q.answer_options.length === 0) {
+          logger_error('Invalid answer_options in predefined question:', q)
+          return // Stop processing
+        }
+      }
 
       if (predefinedQuestions.length > 0) {
         const existingQuestions = await getQuestions()


### PR DESCRIPTION
This PR introduces a new feature that processes a `predefined-questions.json` file on application startup. If the file is present in the `data` directory, its contents are used to populate the main questions list, providing a streamlined way to seed the quiz with initial data. After processing, the predefined questions file is deleted to prevent duplicate entries on subsequent restarts.

**Specifically, it addresses and includes the following:**

- Modified the `initStorage` function to include the new import logic.
- Added a check for `predefined-questions.json` on startup.
- Introduced the `InputQuestion` type for handling partial question data.
- Mapped the imported questions to the standard `Question` format, assigning new IDs.
- Integrated the new questions into the existing `questions.json` file.
- Ensured the `predefined-questions.json` file is removed after a successful import.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically loads predefined questions on startup and merges new items into your existing list with generated IDs, avoiding duplicates by question text.
* **Bug Fixes**
  * Startup safely skips or logs invalid/malformed predefined data so initialization remains reliable and existing questions are not disturbed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->