### PR TITLE
fix: Broadcast results update via WebSocket on question publish

### DIFF
--- a/server/utils/storage.ts
+++ b/server/utils/storage.ts
@@ -217,6 +217,10 @@ export async function publishQuestion(questionId: string): Promise<Question | un
 
       // Clear all answers when publishing new question
       await fs.writeFile(ANSWERS_FILE, JSON.stringify([]))
+
+      // Broadcast the new question as a results update
+      const results = await getResultsForQuestion(question.id)
+      broadcast('results-update', results)
     }
     return question
   }


### PR DESCRIPTION
Fixes missing real-time synchronization when publishing questions. The system now broadcasts results updates via WebSocket to all connected clients when a question is published.

**Specifically, it addresses and includes the following:**

- Added `broadcast('results-update', results)` call in `publishQuestion` function
- Retrieves current results using `getResultsForQuestion(question.id)` before broadcasting
- Broadcasts occur immediately after clearing answers for the newly published question
- Connected clients receive real-time updates without manual refresh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When a new question is published, current results are now computed and broadcast in real time.
  * Users immediately see up-to-date results for the newly published question without needing to refresh or wait for the next update.
  * Enhances live experience by ensuring result views stay synchronized across all participants as soon as a question goes live.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->