### PR TITLE
feat: Add note functionality for questions

### DIFF
--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -10,9 +10,11 @@ const allQuestions = ref<Question[]>([])
 const newQuestion = ref<{
   question_text: string
   answer_options: AnswerOption[]
+  note?: string
 }>({
   question_text: '',
-  answer_options: [{ text: '' }, { text: '' }]
+  answer_options: [{ text: '' }, { text: '' }],
+  note: ''
 })
 
 // Load questions
@@ -63,7 +65,8 @@ async function handleCreateQuestion() {
       method: 'POST',
       body: {
         question_text: newQuestion.value.question_text,
-        answer_options: filteredOptions
+        answer_options: filteredOptions,
+        note: newQuestion.value.note
       }
     })
 
@@ -72,7 +75,8 @@ async function handleCreateQuestion() {
     // Reset form
     newQuestion.value = {
       question_text: '',
-      answer_options: [{ text: '' }, { text: '' }]
+      answer_options: [{ text: '' }, { text: '' }],
+      note: ''
     }
 
     // alert('Question created successfully')
@@ -177,6 +181,12 @@ function removeOption(index: number) {
             class="p-3 border-2 border-black text-base min-h-[100px] resize-y bg-white font-sans"
           ></textarea>
 
+          <textarea
+            v-model="newQuestion.note"
+            placeholder="Enter a note for the question (optional, only for admins)"
+            class="p-3 border-2 border-black text-base min-h-[70px] resize-y bg-white font-sans"
+          ></textarea>
+
           <div>
             <h3 class="mb-2.5 text-lg">Answer Options</h3>
             <div v-for="(option, index) in newQuestion.answer_options" :key="index" class="flex gap-2.5 mb-2.5">
@@ -221,6 +231,7 @@ function removeOption(index: number) {
             :class="{ 'opacity-50': question.alreadyPublished }"
           >
             <p class="font-bold mb-2.5">{{ question.question_text }}</p>
+            <p v-if="question.note" class="text-sm text-gray-600 mb-2.5 p-2 bg-gray-200 border border-black">{{ question.note }}</p>
             <ul class="list-disc list-inside p-0 mb-4">
               <li v-for="(option, index) in question.answer_options" :key="index">
                 {{ option.text }} <span v-if="option.emoji">{{ option.emoji }}</span>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -103,8 +103,6 @@ async function submitAnswer() {
     }
   }
 }
-
-
 </script>
 
 <template>

--- a/app/pages/results.vue
+++ b/app/pages/results.vue
@@ -135,6 +135,11 @@ function getPercentage(count: number) {
           </div>
         </div>
       </div>
+
+      <!-- Note Display -->
+      <div v-if="results.question.note && !hideResults" class="mt-8 p-4 bg-gray-100 border-2 border-black">
+        <p>{{ results.question.note }}</p>
+      </div>
     </UiSection>
 
     <!-- No Active Question -->

--- a/app/types.ts
+++ b/app/types.ts
@@ -10,6 +10,7 @@ export interface Question {
   is_locked: boolean
   createdAt: string
   alreadyPublished: boolean
+  note?: string
 }
 
 export type UserQuestion = Omit<Question, 'answer_options'> & {

--- a/app/types.ts
+++ b/app/types.ts
@@ -13,7 +13,7 @@ export interface Question {
   note?: string
 }
 
-export type UserQuestion = Omit<Question, 'answer_options'> & {
+export type UserQuestion = Omit<Question, 'answer_options' | 'note'> & {
   answer_options: string[]
 }
 

--- a/server/api/questions/active.get.ts
+++ b/server/api/questions/active.get.ts
@@ -4,9 +4,10 @@ export default defineEventHandler(async (): Promise<UserQuestion | { message: st
   const question = await getActiveQuestion()
 
   if (question) {
-    // Strip emojis from answer options before sending to the client
+    // Strip emojis and notes from the question before sending to the client
+    const { note, ...questionForUser } = question
     return {
-      ...question,
+      ...questionForUser,
       answer_options: question.answer_options.map(option => option.text)
     }
   }

--- a/server/api/questions/create.post.ts
+++ b/server/api/questions/create.post.ts
@@ -4,7 +4,7 @@ export default defineEventHandler(async (event) => {
   verifyAdmin(event)
 
   const body = await readBody(event) as Omit<Question, 'id' | 'is_locked'>
-  const { question_text: raw_question_text, answer_options: raw_answer_options } = body
+  const { question_text: raw_question_text, answer_options: raw_answer_options, note: raw_note } = body
 
   // Validate and sanitize question_text
   const question_text = typeof raw_question_text === 'string' ? raw_question_text.trim() : ''
@@ -37,9 +37,12 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  const note = typeof raw_note === 'string' ? raw_note.trim() : undefined
+
   const question = await createQuestion({
     question_text,
-    answer_options
+    answer_options,
+    note
   })
 
   return question


### PR DESCRIPTION
This PR introduces a new `note` field for questions, allowing admins to add internal remarks. The note is manageable through the admin dashboard and is displayed on the results page, conditionally hidden based on view settings.

**Specifically, it addresses and includes the following:**

- Updated the `Question` type in `app/types.ts` to include the optional `note` field.
- Added a `note` textarea to the question creation form in `app/pages/admin.vue`.
- Modified the question creation endpoint (`server/api/questions/create.post.ts`) to process and save the `note`.
- Integrated the note display into the "All Questions" section of the admin dashboard.
- Implemented conditional rendering of the note on the `app/pages/results.vue` page, respecting the `hideResults` parameter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Admins can add an optional note when preparing a question.
  - Notes appear on question cards in All Questions.
  - Results page displays the note for a question when available; notes remain hidden while voting or when results are hidden.

- Style
  - Minor whitespace cleanup for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->