### PR TITLE
fix: Resolve file lock contention in publishQuestion

### DIFF
--- a/server/utils/storage.ts
+++ b/server/utils/storage.ts
@@ -219,7 +219,7 @@ export async function publishQuestion(questionId: string): Promise<Question | un
       await fs.writeFile(ANSWERS_FILE, JSON.stringify([]))
 
       // Broadcast the new question as a results update
-      const results = await getResultsForQuestion(question.id, questions)
+      const results = await getResultsForQuestion(question.id, questions, [])
       broadcast('results-update', results)
     }
     return question
@@ -361,12 +361,12 @@ export async function validateAdmin(username: string, password: string, event?: 
 }
 
 // Get results for current question
-export async function getResultsForQuestion(questionId: string, allQuestions?: Question[]): Promise<Results | null> {
+export async function getResultsForQuestion(questionId: string, allQuestions?: Question[], allAnswers?: Answer[]): Promise<Results | null> {
   const questions = allQuestions || await getQuestions()
   const question = questions.find(q => q.id === questionId)
   if (!question) return null
 
-  const answers = await getAnswersForQuestion(question.id)
+  const answers = allAnswers || await getAnswersForQuestion(question.id)
 
   // Count votes for each option
   const results: Record<string, { count: number, emoji?: string }> = {}


### PR DESCRIPTION
This PR fixes a server error that occurred when publishing a question due to a file lock being held by another process. The changes prevent a nested lock on the answers file, ensuring the operation completes successfully.

**Specifically, it addresses and includes the following:**

- Modified `getResultsForQuestion` to accept an optional `allAnswers` parameter.
- Updated `publishQuestion` to pass the cleared answers array, avoiding a nested lock.
- Refactored the call chain to prevent redundant file system operations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of results displayed after publishing a question, reducing edge-case inconsistencies.

* **Refactor**
  * Streamlined how results are computed by reusing available answers when possible, reducing redundant fetching and improving responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->