### PR TITLE
feat: add scramble mode for anonymous vote display

### DIFF
--- a/app/pages/results.vue
+++ b/app/pages/results.vue
@@ -30,6 +30,13 @@ const visibility = ref(
   (route.query.visibility as string) || 'hide',
 )
 const hideResults = ref(visibility.value.startsWith('hide'))
+
+const scramble = ref(
+  (route.query.scramble as string) || 'show',
+)
+const scrambleResults = ref(scramble.value.startsWith('hide'))
+
+const showEmoji = ref(false)
 const isTogglingLock = ref(false)
 const isPickingUser = ref(false)
 const hasHydratedOnce = ref(false)
@@ -76,6 +83,25 @@ watch(() => results.value?.question.id, (newId, oldId) => {
   else if (visibility.value === 'show') {
     hideResults.value = false
   }
+
+  if (scramble.value === 'hide') {
+    scrambleResults.value = true
+  }
+  else if (scramble.value === 'show') {
+    scrambleResults.value = false
+  }
+
+  showEmoji.value = false
+})
+
+// Optionally shuffle the results order when scramble is active
+const displayResults = computed(() => {
+  if (!results.value) return []
+  const entries = Object.entries(results.value.results)
+  if (scrambleResults.value) {
+    return seededShuffle(entries, results.value.question.id)
+  }
+  return entries
 })
 
 // Calculate bar width
@@ -204,6 +230,12 @@ async function unpublishActiveQuestion() {
                 <UiCheckbox v-model="hideResults" size="small">
                   {{ t('hideButton') }}
                 </UiCheckbox>
+                <UiCheckbox v-model="scrambleResults" size="small">
+                  {{ t('scrambleButton') }}
+                </UiCheckbox>
+                <UiCheckbox v-model="showEmoji" size="small">
+                  {{ t('emojiButton') }}
+                </UiCheckbox>
                 <UiButton
                   :disabled="isTogglingLock"
                   size="small"
@@ -230,14 +262,15 @@ async function unpublishActiveQuestion() {
         <template v-if="results">
           <div class="flex flex-col gap-6">
             <div
-              v-for="(result, option) in results.results"
+              v-for="[option, result] in displayResults"
               :key="option"
               class="flex flex-col gap-2.5"
             >
               <div class="flex items-center justify-between text-lg">
                 <span class="font-bold">
-                  {{ getLocalizedOption(String(option)) }}
-                  <span v-if="result.emoji && !hideResults" class="ml-2">
+                  <template v-if="scrambleResults">?</template>
+                  <template v-else>{{ getLocalizedOption(String(option)) }}</template>
+                  <span v-if="result.emoji && showEmoji" class="ml-2">
                     {{ result.emoji }}
                   </span>
                 </span>
@@ -272,7 +305,10 @@ async function unpublishActiveQuestion() {
           </div>
 
           <!-- Note Display -->
-          <div v-if="results.question.note && !hideResults" class="mt-8 border-2 border-black bg-gray-100 p-4">
+          <div
+            v-if="results.question.note && !hideResults && !scrambleResults"
+            class="mt-8 border-2 border-black bg-gray-100 p-4"
+          >
             <p>{{ getLocalizedText(results.question.note) }}</p>
           </div>
         </template>
@@ -301,6 +337,8 @@ en:
   pageTitle: Live Results
   totalVotes: Total Votes
   hideButton: Hide
+  scrambleButton: Scramble
+  emojiButton: Emoji
   lockedButton: Locked
   openButton: Open
   unpublishButton: Unpublish
@@ -313,6 +351,8 @@ de:
   pageTitle: Live-Ergebnisse
   totalVotes: Stimmen Gesamt
   hideButton: Verstecken
+  scrambleButton: Mischen
+  emojiButton: Emoji
   lockedButton: Gesperrt
   openButton: Offen
   unpublishButton: Veröffentlichung zurückziehen
@@ -325,6 +365,8 @@ ja:
   pageTitle: ライブ結果
   totalVotes: 総投票数
   hideButton: 隠す
+  scrambleButton: シャッフル
+  emojiButton: 絵文字
   lockedButton: ロック済み
   openButton: オープン
   unpublishButton: 公開停止

--- a/app/pages/results.vue
+++ b/app/pages/results.vue
@@ -94,11 +94,17 @@ watch(() => results.value?.question.id, (newId, oldId) => {
   showEmoji.value = false
 })
 
-// Optionally shuffle the results order when scramble is active
+// Shuffle order when scramble is active, or persist shuffled order when
+// scramble=hide was set via URL (so unchecking the checkbox reveals texts
+// without jumping answers back to their original positions).
+const useShuffledOrder = computed(() =>
+  scramble.value === 'hide' || scrambleResults.value,
+)
+
 const displayResults = computed(() => {
   if (!results.value) return []
   const entries = Object.entries(results.value.results)
-  if (scrambleResults.value) {
+  if (useShuffledOrder.value) {
     return seededShuffle(entries, results.value.question.id)
   }
   return entries

--- a/app/utils/seededShuffle.ts
+++ b/app/utils/seededShuffle.ts
@@ -1,0 +1,32 @@
+/** Hashes a string to a 32-bit unsigned integer (djb2 algorithm). */
+function hashString(str: string): number {
+  let hash = 5381
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) >>> 0
+  }
+  return hash
+}
+
+/** Mulberry32 PRNG - returns a function that produces deterministic floats in [0, 1). */
+function mulberry32(seed: number): () => number {
+  let state = seed | 0
+  return () => {
+    state = (state + 0x6D2B79F5) | 0
+    let t = Math.imul(state ^ (state >>> 15), 1 | state)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/** Returns a shuffled copy of the array using a deterministic seed string. */
+export function seededShuffle<T>(array: T[], seed: string): T[] {
+  const copy = [...array]
+  const rng = mulberry32(hashString(seed))
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    const temp = copy[i]!
+    copy[i] = copy[j]!
+    copy[j] = temp
+  }
+  return copy
+}

--- a/docs/url-parameters.md
+++ b/docs/url-parameters.md
@@ -30,11 +30,21 @@ This document describes the GET parameters available for customizing page views.
   - `hide` - Results are hidden whenever a new question appears. The admin can reveal them manually.
   - `show` - Results are shown immediately when a new question appears.
 
+### `scramble`
+
+- **Type**: String (`hide` | `show`)
+- **Default**: `show`
+- **Effect**: Controls whether answers are scrambled (anonymized) when a new question is published.
+  - `hide` - Answers are scrambled on each new question: answer texts are replaced with `?`, emojis are hidden, and the display order is randomized. Bars and vote counts remain visible ("Stimmungsbild" mode).
+  - `show` - Answers are displayed normally (not scrambled) on each new question.
+  - The admin can toggle scrambling manually via the "Scramble" checkbox regardless of this default.
+  - When both `visibility=hide` and `scramble=hide` are active, the strictest hiding applies per element (bars and counts show `?`, answers show `?`, order is randomized).
+
 ### Examples
 
 ```text
 /results
-Standard results view. Results hidden on new questions (default: hide).
+Standard results view. Results hidden on new questions (default: hide), no scrambling.
 
 /results?core
 Core view with minimal UI, no padding, normal scale.
@@ -47,6 +57,12 @@ Core view with results hidden on each new question.
 
 /results?core&visibility=show
 Core view with results shown immediately on each new question.
+
+/results?core&scramble=hide
+Core view with answers scrambled on each new question (Stimmungsbild mode).
+
+/results?core&visibility=hide&scramble=hide
+Core view with results hidden and answers scrambled on each new question.
 
 /results?core&padding=30&scale=1.2&visibility=hide
 Core view with 30px padding, 120% scale, and hidden results.


### PR DESCRIPTION
Add a "scramble" mode to the results page that hides answer texts, removes emojis, and randomizes display order so the audience sees vote distribution without knowing which answer is which (Stimmungsbild). Includes a scramble URL parameter for default behavior on new questions, a scramble checkbox, a separate emoji visibility checkbox, and a seeded shuffle utility for stable-per-question randomization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scramble mode for the results page that replaces answer options with placeholders when active, helping maintain question confidentiality.
  * Introduced UI controls to toggle scramble and emoji display independently.
  * Added URL parameter support to control scramble behavior and default visibility settings.

* **Documentation**
  * Updated with comprehensive URL parameter documentation and practical usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->