### PR TITLE
feat: add leaderboard as admin sub-page

### DIFF
--- a/app/pages/leaderboard.vue
+++ b/app/pages/leaderboard.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+definePageMeta({
+  layout: 'default',
+  middleware: 'auth',
+  footer: true,
+  background: true,
+  localeSwitcher: true,
+})
+
+const { t } = useI18n()
+
+interface LeaderboardEntry {
+  rank: number
+  userId: string
+  nickname: string
+  correctAnswers: number
+}
+
+interface LeaderboardResponse {
+  leaderboard: LeaderboardEntry[]
+  totalQuestionsWithCorrectAnswers: number
+}
+
+const isLoading = ref(false)
+const leaderboard = ref<LeaderboardEntry[]>([])
+const totalQuestionsWithCorrectAnswers = ref(0)
+
+/** Fetch leaderboard data from the API. */
+async function fetchLeaderboard() {
+  isLoading.value = true
+  try {
+    const data = await $fetch<LeaderboardResponse>('/api/results/leaderboard')
+    leaderboard.value = data.leaderboard
+    totalQuestionsWithCorrectAnswers.value = data.totalQuestionsWithCorrectAnswers
+  }
+  catch {
+    leaderboard.value = []
+    totalQuestionsWithCorrectAnswers.value = 0
+  }
+  finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(() => {
+  fetchLeaderboard()
+})
+</script>
+
+<template>
+  <div class="mx-auto max-w-3xl p-5">
+    <UiPageTitle>{{ t('title') }}</UiPageTitle>
+
+    <div class="mb-5 flex items-center justify-between">
+      <p class="text-sm text-gray-500">
+        {{ t('scoredQuestions', { count: totalQuestionsWithCorrectAnswers }) }}
+      </p>
+      <UiButton
+        :disabled="isLoading"
+        size="small"
+        variant="secondary"
+        @click="fetchLeaderboard"
+      >
+        {{ t('refresh') }}
+      </UiButton>
+    </div>
+
+    <UiSection>
+      <p v-if="isLoading" class="py-10 text-center text-lg uppercase tracking-wide text-gray-400">
+        {{ t('loading') }}
+      </p>
+
+      <p
+        v-else-if="leaderboard.length === 0"
+        class="py-10 text-center text-lg uppercase tracking-wide text-gray-400"
+      >
+        {{ t('empty') }}
+      </p>
+
+      <table v-else class="w-full border-collapse">
+        <thead>
+          <tr class="border-b-[3px] border-black text-left uppercase tracking-wide">
+            <th class="p-3 text-center">
+              {{ t('rank') }}
+            </th>
+            <th class="p-3">
+              {{ t('player') }}
+            </th>
+            <th class="p-3 text-center">
+              {{ t('correctAnswers') }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="entry in leaderboard"
+            :key="entry.userId"
+            class="border-b border-gray-300"
+          >
+            <td class="p-3 text-center text-xl font-bold">
+              {{ entry.rank }}
+            </td>
+            <td class="p-3">
+              {{ entry.nickname }}
+              <span class="ml-1 text-xs text-gray-400">({{ entry.userId }})</span>
+            </td>
+            <td class="p-3 text-center text-xl font-bold">
+              {{ entry.correctAnswers }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </UiSection>
+  </div>
+</template>
+
+<i18n lang="yaml">
+en:
+  title: Leaderboard
+  rank: Rank
+  player: Player
+  correctAnswers: Correct
+  refresh: Refresh
+  loading: Loading...
+  empty: No answers submitted yet.
+  scoredQuestions: "Questions with correct answers: {count}"
+de:
+  title: Bestenliste
+  rank: Rang
+  player: Spieler
+  correctAnswers: Richtig
+  refresh: Aktualisieren
+  loading: Laden...
+  empty: Noch keine Antworten eingereicht.
+  scoredQuestions: "Fragen mit richtigen Antworten: {count}"
+ja:
+  title: リーダーボード
+  rank: 順位
+  player: プレイヤー
+  correctAnswers: 正解
+  refresh: 更新
+  loading: 読み込み中...
+  empty: まだ回答が提出されていません。
+  scoredQuestions: "正解のある質問数: {count}"
+</i18n>

--- a/app/pages/leaderboard.vue
+++ b/app/pages/leaderboard.vue
@@ -22,18 +22,22 @@ interface LeaderboardResponse {
 }
 
 const isLoading = ref(false)
+const hasError = ref(false)
 const leaderboard = ref<LeaderboardEntry[]>([])
 const totalQuestionsWithCorrectAnswers = ref(0)
 
 /** Fetch leaderboard data from the API. */
 async function fetchLeaderboard() {
   isLoading.value = true
+  hasError.value = false
   try {
     const data = await $fetch<LeaderboardResponse>('/api/results/leaderboard')
     leaderboard.value = data.leaderboard
     totalQuestionsWithCorrectAnswers.value = data.totalQuestionsWithCorrectAnswers
   }
-  catch {
+  catch (error: unknown) {
+    logger_error('Failed to fetch leaderboard', error)
+    hasError.value = true
     leaderboard.value = []
     totalQuestionsWithCorrectAnswers.value = 0
   }
@@ -68,6 +72,13 @@ onMounted(() => {
     <UiSection>
       <p v-if="isLoading" class="status-message">
         {{ t('loading') }}
+      </p>
+
+      <p
+        v-else-if="hasError"
+        class="status-message"
+      >
+        {{ t('error') }}
       </p>
 
       <p
@@ -123,6 +134,7 @@ en:
   refresh: Refresh
   loading: Loading...
   empty: No answers submitted yet.
+  error: Failed to load leaderboard. Please try again.
   scoredQuestions: "Questions with correct answers: {count}"
 de:
   title: Bestenliste
@@ -132,6 +144,7 @@ de:
   refresh: Aktualisieren
   loading: Laden...
   empty: Noch keine Antworten eingereicht.
+  error: Bestenliste konnte nicht geladen werden. Bitte erneut versuchen.
   scoredQuestions: "Fragen mit richtigen Antworten: {count}"
 ja:
   title: リーダーボード
@@ -141,6 +154,7 @@ ja:
   refresh: 更新
   loading: 読み込み中...
   empty: まだ回答が提出されていません。
+  error: リーダーボードの読み込みに失敗しました。もう一度お試しください。
   scoredQuestions: "正解のある質問数: {count}"
 </i18n>
 

--- a/app/pages/leaderboard.vue
+++ b/app/pages/leaderboard.vue
@@ -66,13 +66,13 @@ onMounted(() => {
     </div>
 
     <UiSection>
-      <p v-if="isLoading" class="py-10 text-center text-lg uppercase tracking-wide text-gray-400">
+      <p v-if="isLoading" class="status-message">
         {{ t('loading') }}
       </p>
 
       <p
         v-else-if="leaderboard.length === 0"
-        class="py-10 text-center text-lg uppercase tracking-wide text-gray-400"
+        class="status-message"
       >
         {{ t('empty') }}
       </p>
@@ -143,3 +143,9 @@ ja:
   empty: まだ回答が提出されていません。
   scoredQuestions: "正解のある質問数: {count}"
 </i18n>
+
+<style scoped>
+.status-message {
+  @apply py-10 text-center text-lg uppercase tracking-wide text-gray-400;
+}
+</style>

--- a/app/pages/leaderboard.vue
+++ b/app/pages/leaderboard.vue
@@ -159,6 +159,8 @@ ja:
 </i18n>
 
 <style scoped>
+@reference "tailwindcss";
+
 .status-message {
   @apply py-10 text-center text-lg uppercase tracking-wide text-gray-400;
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -249,6 +249,26 @@ Pick a random user who voted for a specific option (admin only). Sends a `winner
 
 **Response:** `204 No Content` on success. Returns 404 if no answers or no users found for the option. Returns 503 if the winner is not currently connected.
 
+### GET `/api/results/leaderboard`
+
+Get aggregated player leaderboard across all published questions (admin only). A correct answer is any option with the `⭐` emoji.
+
+**Response:**
+
+```json
+{
+  "leaderboard": [
+    {
+      "rank": 1,
+      "userId": "string",
+      "nickname": "string",
+      "correctAnswers": 5
+    }
+  ],
+  "totalQuestionsWithCorrectAnswers": 10
+}
+```
+
 ## WebSocket Connections
 
 ### GET `/api/websockets/connections`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,7 @@ stage-flow-tools/
 - **`login.vue`** - Admin login
 - **`admin.vue`** - Admin dashboard
 - **`results.vue`** - Results display
+- **`leaderboard.vue`** - Admin leaderboard
 - **`emojis.vue`** - Emoji overlay
 
 ### API Routes

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -38,6 +38,7 @@ Get the quiz application running in minutes.
 - **Quiz Interface**: http://localhost:3000
 - **Admin Dashboard**: http://localhost:3000/admin
 - **Live Results**: http://localhost:3000/results
+- **Leaderboard**: http://localhost:3000/leaderboard
 
 ## Default Credentials
 

--- a/server/api/results/leaderboard.get.ts
+++ b/server/api/results/leaderboard.get.ts
@@ -1,0 +1,77 @@
+export default defineEventHandler(async (event) => {
+  await verifyAdmin(event)
+
+  const questions = await getQuestions()
+  const answers = await getAnswers()
+
+  // Only consider published questions
+  const publishedQuestions = questions.filter(q => q.alreadyPublished)
+
+  // Build a map of questionId -> set of correct answer texts (lowercase en)
+  const correctAnswersByQuestion = new Map<string, Set<string>>()
+  for (const question of publishedQuestions) {
+    const correctTexts = new Set<string>()
+    for (const option of question.answer_options) {
+      if (option.emoji === '\u2B50') {
+        correctTexts.add(option.text.en.toLowerCase())
+      }
+    }
+    if (correctTexts.size > 0) {
+      correctAnswersByQuestion.set(question.id, correctTexts)
+    }
+  }
+
+  // Aggregate scores per user
+  const userScores = new Map<string, { nickname: string, correctAnswers: number }>()
+
+  for (const answer of answers) {
+    const correctTexts = correctAnswersByQuestion.get(answer.question_id)
+    if (!correctTexts) continue
+
+    const isCorrect = correctTexts.has(answer.selected_answer.en.toLowerCase())
+    if (!isCorrect) continue
+
+    const existing = userScores.get(answer.user_id)
+    if (existing) {
+      existing.correctAnswers++
+    }
+    else {
+      userScores.set(answer.user_id, {
+        nickname: answer.user_nickname,
+        correctAnswers: 1,
+      })
+    }
+  }
+
+  // Sort descending by correctAnswers
+  const sorted = [...userScores.entries()]
+    .sort((a, b) => b[1].correctAnswers - a[1].correctAnswers)
+
+  // Apply dense ranking
+  const leaderboard: Array<{
+    rank: number
+    userId: string
+    nickname: string
+    correctAnswers: number
+  }> = []
+
+  let currentRank = 0
+  let previousScore = -1
+  for (const [userId, data] of sorted) {
+    if (data.correctAnswers !== previousScore) {
+      currentRank = leaderboard.length + 1
+      previousScore = data.correctAnswers
+    }
+    leaderboard.push({
+      rank: currentRank,
+      userId,
+      nickname: data.nickname,
+      correctAnswers: data.correctAnswers,
+    })
+  }
+
+  return {
+    leaderboard,
+    totalQuestionsWithCorrectAnswers: correctAnswersByQuestion.size,
+  }
+})

--- a/server/api/results/leaderboard.get.ts
+++ b/server/api/results/leaderboard.get.ts
@@ -59,7 +59,7 @@ export default defineEventHandler(async (event) => {
   let previousScore = -1
   for (const [userId, data] of sorted) {
     if (data.correctAnswers !== previousScore) {
-      currentRank = leaderboard.length + 1
+      currentRank += 1
       previousScore = data.correctAnswers
     }
     leaderboard.push({


### PR DESCRIPTION
This PR adds a leaderboard for calculating the correct answers made by users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responsive Leaderboard page showing rank, player nickname (with ID), correct-answer counts, loading/empty/error states, and a manual refresh button.
  * Multi-language support (en, de, ja) for leaderboard UI.

* **Documentation**
  * Added API docs for a leaderboard endpoint and updated quick-start and architecture docs with leaderboard access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->