### PR TITLE
feat: add assets directory to Cloudflare configuration

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -43,6 +43,9 @@ jobs:
           main = ".output/server/index.mjs"
           compatibility_date = "2025-07-15"
 
+          [assets]
+          directory = ".output/public"
+
           [vars]
           NUXT_ADMIN_USERNAME = "${{ vars.NUXT_ADMIN_USERNAME || 'admin' }}"
           NUXT_PUBLIC_EMOJI_COOLDOWN_MS = "${{ vars.NUXT_PUBLIC_EMOJI_COOLDOWN_MS || '1500' }}"

--- a/docs/deployment-cloudflare.md
+++ b/docs/deployment-cloudflare.md
@@ -190,7 +190,7 @@ npx wrangler kv key put --binding=STAGE_FLOW_DATA "questions" '[
 For larger datasets, use a file:
 
 ```bash
-npx wrangler kv key put --binding=STAGE_FLOW_DATA "questions" --path=./my-questions.json
+npx wrangler kv key put --binding=STAGE_FLOW_DATA "questions" --path=./my-questions.json --preview false
 ```
 
 The JSON format matches the `Question[]` schema documented in [storage.md](storage.md).

--- a/docs/deployment-cloudflare.md
+++ b/docs/deployment-cloudflare.md
@@ -88,6 +88,9 @@ name = "stage-flow-tools"
 main = ".output/server/index.mjs"
 compatibility_date = "2025-07-15"
 
+[assets]
+directory = ".output/public"
+
 [vars]
 NUXT_ADMIN_USERNAME = "admin"
 NUXT_PUBLIC_EMOJI_COOLDOWN_MS = "1500"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@paralleldrive/cuid2": "~2.2.2",
     "@vueuse/core": "~13.9.0",
     "@vueuse/nuxt": "~13.9.0",
+    "cross-env": "~10.1.0",
     "crossws": "~0.4.1",
     "eslint": "~10.0.3",
     "eslint-plugin-format": "~2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@vueuse/nuxt':
         specifier: ~13.9.0
         version: 13.9.0(magicast@0.5.2)(nuxt@4.1.3(@parcel/watcher@2.5.6)(@types/node@25.4.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@10.0.3(jiti@2.6.1))(ioredis@5.10.0)(magicast@0.5.2)(optionator@0.9.4)(rollup@4.59.0)(srvx@0.11.9)(terser@5.46.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))(vue-tsc@3.1.8(typescript@5.9.3))(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
+      cross-env:
+        specifier: ~10.1.0
+        version: 10.1.0
       crossws:
         specifier: 0.4.1
         version: 0.4.1(srvx@0.11.9)
@@ -308,6 +311,9 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@es-joy/jsdoccomment@0.84.0':
     resolution: {integrity: sha512-0xew1CxOam0gV5OMjh2KjFQZsKL2bByX1+q4j3E73MpYIdyUxcZb/xQct9ccUb+ve5KGUYbCUxyPnYB7RbuP+w==}
@@ -2731,6 +2737,11 @@ packages:
   croner@9.1.0:
     resolution: {integrity: sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==}
     engines: {node: '>=18.0'}
+
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -5681,6 +5692,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@es-joy/jsdoccomment@0.84.0':
     dependencies:
       '@types/estree': 1.0.8
@@ -8008,6 +8021,11 @@ snapshots:
       readable-stream: 4.7.0
 
   croner@9.1.0: {}
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -6,6 +6,9 @@ name = "stage-flow-tools"
 main = ".output/server/index.mjs"
 compatibility_date = "2025-07-15"
 
+[assets]
+directory = ".output/public"
+
 [vars]
 NUXT_ADMIN_USERNAME = "admin"
 NUXT_PUBLIC_EMOJI_COOLDOWN_MS = "1500"


### PR DESCRIPTION
This PR updates the Cloudflare deployment configuration by adding the assets directory to `wrangler.toml` and related documentation. It also fixes incorrect CLI parameters in the deployment guide and adds the `cross-env` dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cloudflare deployment guide with static assets serving configuration
  * Updated key-value seeding command examples with corrected CLI syntax

* **Chores**
  * Updated build configuration and tooling to support static assets handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->