### PR TITLE
feat: add admin reset action for active question answers with attendee answer clear

### DIFF
--- a/app/composables/useQuizSocket.ts
+++ b/app/composables/useQuizSocket.ts
@@ -9,6 +9,28 @@ export const useQuizSocket = (channel = 'default') => {
   const totalConnections = ref(0)
   const userId = useLocalStorage<string | null>('quiz-user-id', null)
 
+  function clearStoredAnswer(questionId: string) {
+    selectedAnswer.value = null
+
+    if (import.meta.client) {
+      sessionStorage.removeItem(`answer-${questionId}`)
+    }
+  }
+
+  function restoreStoredAnswer(questionId: string) {
+    if (!import.meta.client) {
+      selectedAnswer.value = null
+      return
+    }
+
+    const savedAnswer = sessionStorage.getItem(`answer-${questionId}`)
+    const parsedAnswer = savedAnswer === null ? Number.NaN : Number(savedAnswer)
+
+    selectedAnswer.value = Number.isInteger(parsedAnswer) && parsedAnswer >= 0
+      ? parsedAnswer
+      : null
+  }
+
   const wsEndpoint = computed(() => {
     if (import.meta.client && !userId.value) {
       userId.value = createId()
@@ -43,17 +65,17 @@ export const useQuizSocket = (channel = 'default') => {
           selectedAnswer.value = null
         }
         else if (previousQuestionId !== parsed.data.id) {
-          // Restore previously saved answer for this question, or clear selection
-          const savedAnswer = sessionStorage.getItem(`answer-${parsed.data.id}`)
-          const parsedAnswer = savedAnswer === null ? Number.NaN : Number(savedAnswer)
-          selectedAnswer.value = Number.isInteger(parsedAnswer) && parsedAnswer >= 0
-            ? parsedAnswer
-            : null
+          restoreStoredAnswer(parsed.data.id)
         }
       }
       else if (parsed.event === 'lock-status') {
         if (activeQuestion.value && activeQuestion.value.id === parsed.data.questionId) {
           activeQuestion.value.is_locked = parsed.data.is_locked
+        }
+      }
+      else if (parsed.event === 'answers-reset') {
+        if (activeQuestion.value && activeQuestion.value.id === parsed.data.questionId) {
+          clearStoredAnswer(parsed.data.questionId)
         }
       }
       else if (parsed.event === 'results-update') {

--- a/app/pages/admin/questions.vue
+++ b/app/pages/admin/questions.vue
@@ -109,6 +109,7 @@ const allQuestions = ref<Question[]>([])
 const questionFormSection = ref<HTMLElement | null>(null)
 const editingQuestionId = ref<string | null>(null)
 const isSavingQuestion = ref(false)
+const isResettingAnswers = ref(false)
 const questionForm = ref<QuestionForm>(createDefaultQuestionForm())
 const isEditMode = computed(() => editingQuestionId.value !== null)
 const formTitle = computed(() => isEditMode.value ? t('editQuestionTitle') : t('prepareNextQuestion'))
@@ -266,6 +267,33 @@ async function publishNextQuestion() {
   }
 }
 
+async function resetAnswers() {
+  if (!activeQuestion.value || isResettingAnswers.value) {
+    return
+  }
+
+  if (!window.confirm(t('confirmResetAnswers'))) {
+    return
+  }
+
+  isResettingAnswers.value = true
+
+  try {
+    await $fetch('/api/answers/reset', {
+      method: 'POST',
+    })
+
+    await loadQuestions()
+  }
+  catch (error: unknown) {
+    logger_error('Failed to reset answers from questions page', error)
+    alert(t('failedResetAnswers'))
+  }
+  finally {
+    isResettingAnswers.value = false
+  }
+}
+
 // Add option
 function addOption() {
   questionForm.value.answer_options.push({ text: '{\n  "en": ""\n}', emoji: '' })
@@ -316,6 +344,9 @@ function removeOption(index: number) {
               </NuxtLink>
               <UiButton @click="toggleLock">
                 {{ activeQuestion.is_locked ? t('unlockQuestion') : t('lockQuestion') }}
+              </UiButton>
+              <UiButton :disabled="isResettingAnswers" variant="danger" @click="resetAnswers">
+                {{ isResettingAnswers ? t('resettingAnswers') : t('resetAnswers') }}
               </UiButton>
               <UiButton variant="secondary" @click="publishNextQuestion">
                 {{ t('publishNext') }} →
@@ -476,8 +507,11 @@ en:
   viewLiveResults: View Live Results
   lockQuestion: Lock Question
   unlockQuestion: Unlock Question
+  resetAnswers: Reset Answers
+  resettingAnswers: Resetting...
   publishNext: Publish Next
   unpublishButton: Unpublish
+  confirmResetAnswers: Delete all submitted answers for current question?
   noActiveQuestion: No active question
   prepareNextQuestion: Prepare Next Question
   editQuestionTitle: Edit Question
@@ -507,6 +541,7 @@ en:
   failedUpdateQuestion: Failed to update question.
   failedPublishQuestion: Failed to publish question.
   failedToggleLock: Failed to toggle lock status.
+  failedResetAnswers: Failed to reset answers.
   failedUnpublish: Failed to unpublish active question.
   failedPublishNext: Failed to publish next question. There may be no unpublished questions left.
 de:
@@ -519,8 +554,11 @@ de:
   viewLiveResults: Live-Ergebnisse anzeigen
   lockQuestion: Frage sperren
   unlockQuestion: Frage entsperren
+  resetAnswers: Antworten zurücksetzen
+  resettingAnswers: Antworten werden zurückgesetzt...
   publishNext: Nächste veröffentlichen
   unpublishButton: Veröffentlichung zurückziehen
+  confirmResetAnswers: Alle abgegebenen Antworten für die aktuelle Frage löschen?
   noActiveQuestion: Keine aktive Frage
   prepareNextQuestion: Nächste Frage vorbereiten
   editQuestionTitle: Frage bearbeiten
@@ -550,6 +588,7 @@ de:
   failedUpdateQuestion: Frage konnte nicht aktualisiert werden.
   failedPublishQuestion: Frage konnte nicht veröffentlicht werden.
   failedToggleLock: Sperrstatus konnte nicht geändert werden.
+  failedResetAnswers: Antworten konnten nicht zurückgesetzt werden.
   failedUnpublish: Veröffentlichung konnte nicht zurückgezogen werden.
   failedPublishNext: >-
     Nächste Frage konnte nicht veröffentlicht werden.
@@ -564,8 +603,11 @@ ja:
   viewLiveResults: ライブ結果を表示
   lockQuestion: 質問をロック
   unlockQuestion: 質問のロックを解除
+  resetAnswers: 回答をリセット
+  resettingAnswers: リセット中...
   publishNext: 次を公開
   unpublishButton: 公開停止
+  confirmResetAnswers: 現在の質問の回答を全て削除しますか？
   noActiveQuestion: アクティブな質問はありません
   prepareNextQuestion: 次の質問を準備
   editQuestionTitle: 質問を編集
@@ -595,6 +637,7 @@ ja:
   failedUpdateQuestion: 質問の更新に失敗しました。
   failedPublishQuestion: 質問の公開に失敗しました。
   failedToggleLock: ロック状態の切り替えに失敗しました。
+  failedResetAnswers: 回答のリセットに失敗しました。
   failedUnpublish: 公開停止に失敗しました。
   failedPublishNext: 次の質問の公開に失敗しました。未公開の質問がない可能性があります。
 </i18n>

--- a/app/pages/admin/results.vue
+++ b/app/pages/admin/results.vue
@@ -39,6 +39,7 @@ const scrambleResults = ref(scramble.value.startsWith('hide'))
 const showEmoji = ref(false)
 const isTogglingLock = ref(false)
 const isPickingUser = ref(false)
+const isResettingAnswers = ref(false)
 const hasHydratedOnce = ref(false)
 
 // Dynamic styles for core view
@@ -203,6 +204,30 @@ async function unpublishActiveQuestion() {
     alert('Failed to unpublish active question.')
   }
 }
+
+async function resetAnswers() {
+  if (!results.value?.question || isResettingAnswers.value) return
+
+  if (!window.confirm(t('confirmResetAnswers'))) {
+    return
+  }
+
+  isResettingAnswers.value = true
+
+  try {
+    await $fetch('/api/answers/reset', {
+      method: 'POST',
+    })
+    await refreshResults()
+  }
+  catch (error: unknown) {
+    logger_error('Failed to reset answers from results page', error)
+    alert(t('failedResetAnswers'))
+  }
+  finally {
+    isResettingAnswers.value = false
+  }
+}
 </script>
 
 <template>
@@ -249,6 +274,14 @@ async function unpublishActiveQuestion() {
                   @click="toggleLock"
                 >
                   {{ results.question.is_locked ? `🔒 ${t('lockedButton')}` : `🔓 ${t('openButton')}` }}
+                </UiButton>
+                <UiButton
+                  :disabled="isResettingAnswers"
+                  size="small"
+                  variant="danger"
+                  @click="resetAnswers"
+                >
+                  {{ isResettingAnswers ? t('resettingAnswers') : t('resetAnswers') }}
                 </UiButton>
                 <UiButton size="small" variant="secondary" @click="unpublishActiveQuestion">
                   {{ t('unpublishButton') }}
@@ -347,9 +380,13 @@ en:
   emojiButton: Emoji
   lockedButton: Locked
   openButton: Open
+  resetAnswers: Reset Answers
+  resettingAnswers: Resetting...
   unpublishButton: Unpublish
   refreshButton: Refresh
   nextButton: Next
+  confirmResetAnswers: Delete all submitted answers for current question?
+  failedResetAnswers: Failed to reset answers.
   votes: votes
   noActiveQuestion: No Active Question
   waitingForQuestion: Waiting for a question to be published...
@@ -361,9 +398,13 @@ de:
   emojiButton: Emoji
   lockedButton: Gesperrt
   openButton: Offen
+  resetAnswers: Antworten zurücksetzen
+  resettingAnswers: Antworten werden zurückgesetzt...
   unpublishButton: Veröffentlichung zurückziehen
   refreshButton: Aktualisieren
   nextButton: Nächste
+  confirmResetAnswers: Alle abgegebenen Antworten für die aktuelle Frage löschen?
+  failedResetAnswers: Antworten konnten nicht zurückgesetzt werden.
   votes: Stimmen
   noActiveQuestion: Keine aktive Frage
   waitingForQuestion: Warten auf die Veröffentlichung einer Frage...
@@ -375,9 +416,13 @@ ja:
   emojiButton: 絵文字
   lockedButton: ロック済み
   openButton: オープン
+  resetAnswers: 回答をリセット
+  resettingAnswers: リセット中...
   unpublishButton: 公開停止
   refreshButton: 更新
   nextButton: 次へ
+  confirmResetAnswers: 現在の質問の回答を全て削除しますか？
+  failedResetAnswers: 回答のリセットに失敗しました。
   votes: 票
   noActiveQuestion: アクティブな質問はありません
   waitingForQuestion: 質問が公開されるのを待っています...

--- a/docs/api.md
+++ b/docs/api.md
@@ -345,6 +345,25 @@ Retract a user's answer.
 }
 ```
 
+### POST `/api/answers/reset`
+
+Clear all submitted answers for current active question (admin only).
+
+This endpoint derives target question from current active question. Request body is empty.
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "questionId": "string"
+}
+```
+
+**Error cases:**
+
+- `404` - no active question
+
 ## Emojis
 
 ### POST `/api/emojis/submit`

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -71,6 +71,23 @@ Bundled voting results (batched every 2 seconds)
 }
 ```
 
+`results-update` may be sent immediately for explicit admin actions such as answer reset.
+
+#### `answers-reset`
+
+Sent on default channel when admin clears all answers for current active question.
+
+Clients should clear local answer state for matching `questionId` so voting can start fresh if question stays unlocked.
+
+```json
+{
+  "event": "answers-reset",
+  "data": {
+    "questionId": "string"
+  }
+}
+```
+
 #### `connections-update`
 
 Peer count change (on connect/disconnect)
@@ -160,6 +177,7 @@ ws.onclose = () => {
 
 - New question published
 - Lock status changed
+- Answer reset
 
 ### Bundled Events
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "eslint-plugin-tailwindcss": "~4.0.0-alpha.2",
     "eslint-plugin-yml": "~3.3.1",
     "jose": "~6.2.1",
-    "npm-run-all2": "~8.0.4",
     "nuxi": "~3.28.0",
     "prettier": "~3.8.1",
     "prettier-package-json": "~2.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,9 +91,6 @@ importers:
       jose:
         specifier: ~6.2.1
         version: 6.2.1
-      npm-run-all2:
-        specifier: ~8.0.4
-        version: 8.0.4
       nuxi:
         specifier: ~3.28.0
         version: 3.28.0
@@ -4526,10 +4523,6 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  json-parse-even-better-errors@4.0.0:
-    resolution: {integrity: sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-
   json-schema-to-typescript-lite@15.0.0:
     resolution: {integrity: sha512-5mMORSQm9oTLyjM4mWnyNBi2T042Fhg1/0gCIB6X8U/LVpM2A+Nmj2yEyArqVouDmFThDxpEXcnTgSrjkGJRFA==}
 
@@ -4766,10 +4759,6 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
-  memorystream@0.3.1:
-    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
-    engines: {node: '>= 0.10.0'}
-
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -4948,15 +4937,6 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
-
-  npm-normalize-package-bin@4.0.0:
-    resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-
-  npm-run-all2@8.0.4:
-    resolution: {integrity: sha512-wdbB5My48XKp2ZfJUlhnLVihzeuA1hgBnqB2J9ahV77wLS+/YAJAlN8I+X3DIFIPZ3m5L7nplmlbhNiFDmXRDA==}
-    engines: {node: ^20.5.0 || >=22.0.0, npm: '>= 10'}
-    hasBin: true
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -5204,11 +5184,6 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
-
-  pidtree@0.6.0:
-    resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
-    engines: {node: '>=0.10'}
-    hasBin: true
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -5532,10 +5507,6 @@ packages:
 
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
-
-  read-package-json-fast@4.0.0:
-    resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
-    engines: {node: ^18.17.0 || >=20.5.0}
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -10549,8 +10520,6 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
-  json-parse-even-better-errors@4.0.0: {}
-
   json-schema-to-typescript-lite@15.0.0:
     dependencies:
       '@apidevtools/json-schema-ref-parser': 14.2.1(@types/json-schema@7.0.15)
@@ -10811,8 +10780,6 @@ snapshots:
 
   media-typer@0.3.0: {}
 
-  memorystream@0.3.1: {}
-
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -11036,19 +11003,6 @@ snapshots:
       abbrev: 3.0.1
 
   normalize-path@3.0.0: {}
-
-  npm-normalize-package-bin@4.0.0: {}
-
-  npm-run-all2@8.0.4:
-    dependencies:
-      ansi-styles: 6.2.3
-      cross-spawn: 7.0.6
-      memorystream: 0.3.1
-      picomatch: 4.0.3
-      pidtree: 0.6.0
-      read-package-json-fast: 4.0.0
-      shell-quote: 1.8.3
-      which: 5.0.0
 
   npm-run-path@5.3.0:
     dependencies:
@@ -11531,8 +11485,6 @@ snapshots:
 
   picomatch@4.0.3: {}
 
-  pidtree@0.6.0: {}
-
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
@@ -11849,11 +11801,6 @@ snapshots:
   read-cache@1.0.0:
     dependencies:
       pify: 2.3.0
-
-  read-package-json-fast@4.0.0:
-    dependencies:
-      json-parse-even-better-errors: 4.0.0
-      npm-normalize-package-bin: 4.0.0
 
   readable-stream@2.3.8:
     dependencies:

--- a/server/api/answers/reset.post.ts
+++ b/server/api/answers/reset.post.ts
@@ -1,0 +1,29 @@
+import { WebSocketChannel } from '~/types'
+
+export default defineEventHandler(async (event) => {
+  await verifyAdmin(event)
+
+  const activeQuestion = await getActiveQuestion()
+
+  if (!activeQuestion) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'No active question',
+    })
+  }
+
+  await clearAnswersForQuestion(activeQuestion.id)
+
+  const results = await getResultsForQuestion(activeQuestion.id)
+
+  broadcast('answers-reset', { questionId: activeQuestion.id }, WebSocketChannel.DEFAULT)
+
+  if (results) {
+    broadcast('results-update', results, WebSocketChannel.RESULTS)
+  }
+
+  return {
+    success: true,
+    questionId: activeQuestion.id,
+  }
+})

--- a/server/utils/storage.ts
+++ b/server/utils/storage.ts
@@ -345,6 +345,16 @@ export async function retractAnswer(userId: string, questionId: string): Promise
   return getAnswersForQuestion(questionId)
 }
 
+/** Deletes all stored answers for one question. */
+export async function clearAnswersForQuestion(questionId: string): Promise<void> {
+  await initStorage()
+
+  getDatabase()
+    .delete(answers)
+    .where(eq(answers.questionId, questionId))
+    .run()
+}
+
 // Admin operations
 export async function validateAdmin(username: string, password: string, event?: H3Event): Promise<boolean> {
   const config = event ? useRuntimeConfig(event) : useRuntimeConfig()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can now reset all submitted answers for the current active question via dedicated buttons on the questions and results pages.
  * Added real-time notification when answers are reset across connected clients.

* **Documentation**
  * Updated API and WebSocket documentation for the new reset functionality.

* **Chores**
  * Removed unused development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->