### PR TITLE
feat: batch emoji reactions over WebSockets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,19 @@ NUXT_ADMIN_PASSWORD=123
 # Leave empty to disable this auth path. Only one exact token is accepted.
 NUXT_ADMIN_TOKEN=
 
+# Delay in milliseconds before the server flushes a queued emoji batch.
+# Default from nuxt.config.ts: 150
+NUXT_EMOJI_BATCH_TICK_MS=150
+
+# Maximum emoji reactions in one server-to-overlay WebSocket batch.
+# Default from nuxt.config.ts: 1200
+NUXT_EMOJI_BATCH_MAX_SIZE=1200
+
+# Maximum pending emoji reactions held in server memory. New reactions are
+# discarded silently when this queue is full.
+# Default from nuxt.config.ts: 25000
+NUXT_EMOJI_QUEUE_MAX_SIZE=25000
+
 # Private internal port for the embedded Drizzle Studio worker.
 # Default from nuxt.config.ts: 64983
 NUXT_DRIZZLE_STUDIO_INTERNAL_PORT=64983

--- a/.env.example
+++ b/.env.example
@@ -15,15 +15,18 @@ NUXT_ADMIN_PASSWORD=123
 NUXT_ADMIN_TOKEN=
 
 # Delay in milliseconds before the server flushes a queued emoji batch.
+# Must be a positive integer.
 # Default from nuxt.config.ts: 150
 NUXT_EMOJI_BATCH_TICK_MS=150
 
 # Maximum emoji reactions in one server-to-overlay WebSocket batch.
+# Must be a positive integer.
 # Default from nuxt.config.ts: 1200
 NUXT_EMOJI_BATCH_MAX_SIZE=1200
 
 # Maximum pending emoji reactions held in server memory. New reactions are
 # discarded silently when this queue is full.
+# Must be a positive integer.
 # Default from nuxt.config.ts: 25000
 NUXT_EMOJI_QUEUE_MAX_SIZE=25000
 

--- a/app/pages/admin/emojis.vue
+++ b/app/pages/admin/emojis.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { getEmojiBatch } from '~/utils/emoji-batch'
+
 definePageMeta({
   layout: 'default',
   middleware: 'auth',
@@ -34,9 +36,9 @@ const { data } = useWebSocket(wsEndpoint, {
 
 watch(data, (newValue) => {
   try {
-    const event = JSON.parse(newValue)
-    if (event.event === 'emoji' && event.data?.emoji && event.data?.id) {
-      addEmoji(event.data.emoji, event.data.id)
+    const event: unknown = JSON.parse(newValue)
+    for (const emoji of getEmojiBatch(event)) {
+      addEmoji(emoji.emoji, emoji.id)
     }
   }
   catch (error) {

--- a/app/types.ts
+++ b/app/types.ts
@@ -30,6 +30,11 @@ export interface Answer {
   timestamp: string
 }
 
+export interface EmojiReaction {
+  emoji: string
+  id: string
+}
+
 export interface Results {
   question: Question
   results: Record<string, { count: number, emoji?: string }>

--- a/app/utils/emoji-batch.test.ts
+++ b/app/utils/emoji-batch.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { getEmojiBatch } from './emoji-batch'
+
+describe('getEmojiBatch', () => {
+  it('returns every valid reaction from an emoji batch event', () => {
+    expect(getEmojiBatch({
+      event: 'emojis',
+      data: [
+        { emoji: '🔥', id: 'first' },
+        { emoji: '👏', id: 'second' },
+      ],
+    })).toEqual([
+      { emoji: '🔥', id: 'first' },
+      { emoji: '👏', id: 'second' },
+    ])
+  })
+
+  it('ignores malformed entries and unrelated events', () => {
+    expect(getEmojiBatch({
+      event: 'emojis',
+      data: [
+        { emoji: '🔥', id: 'first' },
+        { emoji: '', id: 'missing-emoji' },
+        { emoji: '👏' },
+      ],
+    })).toEqual([
+      { emoji: '🔥', id: 'first' },
+    ])
+    expect(getEmojiBatch({ event: 'emoji', data: { emoji: '🔥', id: 'first' } })).toEqual([])
+  })
+})

--- a/app/utils/emoji-batch.ts
+++ b/app/utils/emoji-batch.ts
@@ -1,0 +1,28 @@
+import type { EmojiReaction } from '~/types'
+
+function isEmojiReaction(value: unknown): value is EmojiReaction {
+  return typeof value === 'object'
+    && value !== null
+    && 'emoji' in value
+    && typeof value.emoji === 'string'
+    && value.emoji.length > 0
+    && 'id' in value
+    && typeof value.id === 'string'
+    && value.id.length > 0
+}
+
+/** Returns valid emoji reactions from one server-side emoji batch event. */
+export function getEmojiBatch(value: unknown): EmojiReaction[] {
+  if (
+    typeof value !== 'object'
+    || value === null
+    || !('event' in value)
+    || value.event !== 'emojis'
+    || !('data' in value)
+    || !Array.isArray(value.data)
+  ) {
+    return []
+  }
+
+  return value.data.filter(isEmojiReaction)
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -384,7 +384,7 @@ This endpoint derives target question from current active question. Request body
 
 ### POST `/api/emojis/submit`
 
-Submit an emoji reaction. Broadcasts to all clients on the emojis WebSocket channel. Enforces per-user cooldown.
+Submit an emoji reaction. The server queues reactions for batched delivery to clients on the emojis WebSocket channel and enforces a per-user cooldown. When the configured in-memory queue is full, new reactions are discarded while this endpoint still returns success.
 
 **Request:**
 

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -103,17 +103,19 @@ Peer count change (on connect/disconnect)
 }
 ```
 
-#### `emoji`
+#### `emojis`
 
-Emoji reaction broadcast
+Emoji reaction batch
 
 ```json
 {
-  "event": "emoji",
-  "data": {
-    "emoji": "string",
-    "id": "string (cuid2)"
-  }
+  "event": "emojis",
+  "data": [
+    {
+      "emoji": "string",
+      "id": "string (cuid2)"
+    }
+  ]
 }
 ```
 
@@ -188,6 +190,8 @@ ws.onclose = () => {
 - Results updates (every 2 seconds)
 - Reduces network traffic
 - Smooths UI updates
+- Emoji reactions (every `NUXT_EMOJI_BATCH_TICK_MS` milliseconds, up to
+  `NUXT_EMOJI_BATCH_MAX_SIZE` reactions per batch)
 
 ## Error Handling
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -26,6 +26,9 @@ const configBase: InputConfig<NuxtConfig, ConfigLayerMeta> = {
     adminToken: '',
     adminUsername: 'admin',
     drizzleStudioInternalPort: '64983',
+    emojiBatchMaxSize: 1200,
+    emojiBatchTickMs: 150,
+    emojiQueueMaxSize: 25000,
     jwtSecret: 'tryUJ0zQbstPbTOrezme+Fv+KndzDNRx5lmSeelr2ial2/2yV8HqLeQ2felJafqf',
 
     // Public keys (available on both client and server)

--- a/server/api/emojis/submit.post.test.ts
+++ b/server/api/emojis/submit.post.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vite-plus/test'
+
+const checkEmojiCooldown = vi.fn()
+const enqueueEmoji = vi.fn()
+const readValidatedRequestBody = vi.fn()
+const updateEmojiTimestamp = vi.fn()
+
+vi.mock('@paralleldrive/cuid2', () => ({
+  createId: () => 'emoji-id',
+}))
+
+vi.stubGlobal('checkEmojiCooldown', checkEmojiCooldown)
+vi.stubGlobal('defineApiHandler', <T>(handler: T) => handler)
+vi.stubGlobal('enqueueEmoji', enqueueEmoji)
+vi.stubGlobal('readValidatedRequestBody', readValidatedRequestBody)
+vi.stubGlobal('updateEmojiTimestamp', updateEmojiTimestamp)
+
+const { default: submitEmoji } = await import('./submit.post')
+
+describe('POST /api/emojis/submit', () => {
+  it('records cooldown and returns success when a full queue discards an emoji', async () => {
+    checkEmojiCooldown.mockReturnValue(false)
+    enqueueEmoji.mockReturnValue(false)
+    readValidatedRequestBody.mockResolvedValue({
+      emoji: '🔥',
+      user_id: 'participant-id',
+    })
+
+    await expect(submitEmoji({} as never)).resolves.toEqual({
+      statusCode: 200,
+      body: { message: 'Emoji received.' },
+    })
+    expect(updateEmojiTimestamp).toHaveBeenCalledWith('participant-id')
+    expect(enqueueEmoji).toHaveBeenCalledWith({ emoji: '🔥', id: 'emoji-id' })
+  })
+})

--- a/server/api/emojis/submit.post.ts
+++ b/server/api/emojis/submit.post.ts
@@ -1,5 +1,4 @@
 import { createId } from '@paralleldrive/cuid2'
-import { WebSocketChannel } from '~/types'
 import { EmojiSubmitSchema } from '#shared/utils/validation'
 
 export default defineApiHandler(async (event) => {
@@ -13,12 +12,10 @@ export default defineApiHandler(async (event) => {
   }
 
   updateEmojiTimestamp(user_id)
-
-  // Broadcast the emoji with a unique ID to ensure reactivity on the client
-  broadcast('emoji', { emoji, id: createId() }, WebSocketChannel.EMOJIS)
+  enqueueEmoji({ emoji, id: createId() })
 
   return {
     statusCode: 200,
-    body: { message: 'Emoji received and broadcasted.' },
+    body: { message: 'Emoji received.' },
   }
 })

--- a/server/plugins/emoji-batching.ts
+++ b/server/plugins/emoji-batching.ts
@@ -1,0 +1,7 @@
+import { defineNitroPlugin } from 'nitropack/runtime'
+import { validateEmojiBatchingConfig } from '../utils/emoji-batching-config'
+
+/** Fails startup when emoji batching configuration is unsafe. */
+export default defineNitroPlugin(() => {
+  validateEmojiBatchingConfig(useRuntimeConfig())
+})

--- a/server/utils/emoji-batching-config.test.ts
+++ b/server/utils/emoji-batching-config.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { validateEmojiBatchingConfig } from './emoji-batching-config'
+
+const validConfig = {
+  emojiBatchMaxSize: 1200,
+  emojiBatchTickMs: 150,
+  emojiQueueMaxSize: 25000,
+}
+
+describe('validateEmojiBatchingConfig', () => {
+  it('accepts positive safe-integer settings', () => {
+    expect(() => validateEmojiBatchingConfig(validConfig)).not.toThrow()
+  })
+
+  it.each([
+    'emojiBatchTickMs',
+    'emojiBatchMaxSize',
+    'emojiQueueMaxSize',
+  ])('rejects zero, negative, fractional, and nonnumeric %s values', (key) => {
+    for (const value of [
+      0,
+      -1,
+      0.5,
+      'invalid',
+    ]) {
+      const config: Record<string, unknown> = { ...validConfig }
+      config[key] = value
+
+      expect(() => validateEmojiBatchingConfig(config as typeof validConfig)).toThrowError(
+        `Invalid runtime config ${key}: expected a positive safe integer.`,
+      )
+    }
+  })
+})

--- a/server/utils/emoji-batching-config.ts
+++ b/server/utils/emoji-batching-config.ts
@@ -1,0 +1,18 @@
+type EmojiBatchingRuntimeConfig = {
+  emojiBatchMaxSize: unknown
+  emojiBatchTickMs: unknown
+  emojiQueueMaxSize: unknown
+}
+
+function requirePositiveSafeInteger(value: unknown, key: string): void {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`Invalid runtime config ${key}: expected a positive safe integer.`)
+  }
+}
+
+/** Validates server-side emoji batching settings before the server accepts requests. */
+export function validateEmojiBatchingConfig(config: EmojiBatchingRuntimeConfig): void {
+  requirePositiveSafeInteger(config.emojiBatchTickMs, 'emojiBatchTickMs')
+  requirePositiveSafeInteger(config.emojiBatchMaxSize, 'emojiBatchMaxSize')
+  requirePositiveSafeInteger(config.emojiQueueMaxSize, 'emojiQueueMaxSize')
+}

--- a/server/utils/websocket.test.ts
+++ b/server/utils/websocket.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+import type { Peer } from 'crossws'
+
+import { WebSocketChannel } from '~/types'
+import {
+  addPeer,
+  enqueueEmoji,
+  removePeer,
+} from './websocket'
+
+const runtimeConfig = {
+  emojiBatchMaxSize: 1200,
+  emojiBatchTickMs: 150,
+  emojiQueueMaxSize: 25000,
+}
+
+const peers: Peer[] = []
+
+vi.stubGlobal('logger_error', vi.fn())
+vi.stubGlobal('useRuntimeConfig', () => runtimeConfig)
+
+async function addEmojiPeer(): Promise<Peer & { send: ReturnType<typeof vi.fn> }> {
+  const peer = {
+    id: 'peer-' + peers.length,
+    send: vi.fn(),
+  } as unknown as Peer & { send: ReturnType<typeof vi.fn> }
+
+  peers.push(peer)
+  await addPeer(peer, WebSocketChannel.EMOJIS, '/_ws/default')
+  peer.send.mockClear()
+
+  return peer
+}
+
+afterEach(async () => {
+  for (const peer of peers.splice(0)) {
+    await removePeer(peer)
+  }
+
+  vi.runAllTimers()
+  vi.useRealTimers()
+})
+
+describe('enqueueEmoji', () => {
+  it('emits an ordered batch only after the configured tick', async () => {
+    vi.useFakeTimers()
+    const peer = await addEmojiPeer()
+
+    enqueueEmoji({ emoji: '🔥', id: 'first' })
+    enqueueEmoji({ emoji: '👏', id: 'second' })
+
+    vi.advanceTimersByTime(149)
+    expect(peer.send).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(peer.send).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(peer.send.mock.calls[0]![0])).toEqual({
+      event: 'emojis',
+      data: [
+        { emoji: '🔥', id: 'first' },
+        { emoji: '👏', id: 'second' },
+      ],
+    })
+  })
+
+  it('continues on later ticks when a batch reaches the configured maximum', async () => {
+    vi.useFakeTimers()
+    const peer = await addEmojiPeer()
+
+    for (let index = 0; index < runtimeConfig.emojiBatchMaxSize + 1; index++) {
+      enqueueEmoji({ emoji: '🔥', id: String(index) })
+    }
+
+    vi.advanceTimersByTime(150)
+    expect(JSON.parse(peer.send.mock.calls[0]![0]).data).toHaveLength(runtimeConfig.emojiBatchMaxSize)
+
+    vi.advanceTimersByTime(149)
+    expect(peer.send).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(1)
+    expect(JSON.parse(peer.send.mock.calls[1]![0])).toEqual({
+      event: 'emojis',
+      data: [
+        { emoji: '🔥', id: '1200' },
+      ],
+    })
+  })
+
+  it('discards new reactions when the pending queue is full', () => {
+    vi.useFakeTimers()
+
+    for (let index = 0; index < runtimeConfig.emojiQueueMaxSize; index++) {
+      expect(enqueueEmoji({ emoji: '🔥', id: String(index) })).toBe(true)
+    }
+
+    expect(enqueueEmoji({ emoji: '👏', id: 'discarded' })).toBe(false)
+  })
+})

--- a/server/utils/websocket.ts
+++ b/server/utils/websocket.ts
@@ -1,5 +1,9 @@
 import type { Peer } from 'crossws'
-import type { Results, WebSocketChannel } from '~/types'
+import { WebSocketChannel } from '~/types'
+import type {
+  EmojiReaction,
+  Results,
+} from '~/types'
 
 interface PeerInfo {
   id: string
@@ -22,6 +26,8 @@ interface ResultsBufferState {
 
 const peerSessions = new Map<string, PeerSession>()
 const resultsBuffers = new Map<WebSocketChannel, ResultsBufferState>()
+const emojiBuffer: EmojiReaction[] = []
+let emojiTimeoutId: ReturnType<typeof setTimeout> | undefined
 
 function getSessions(channel?: WebSocketChannel): PeerSession[] {
   const sessions = Array.from(peerSessions.values())
@@ -111,4 +117,39 @@ export function scheduleResultsUpdate(data: Results, channel: WebSocketChannel) 
   }
 
   resultsBuffers.set(channel, state)
+}
+
+function scheduleEmojiBatch(): void {
+  if (emojiTimeoutId !== undefined) {
+    return
+  }
+
+  const config = useRuntimeConfig()
+
+  emojiTimeoutId = setTimeout(() => {
+    emojiTimeoutId = undefined
+
+    const emojis = emojiBuffer.splice(0, config.emojiBatchMaxSize)
+    if (emojis.length > 0) {
+      broadcast('emojis', emojis, WebSocketChannel.EMOJIS)
+    }
+
+    if (emojiBuffer.length > 0) {
+      scheduleEmojiBatch()
+    }
+  }, config.emojiBatchTickMs)
+}
+
+/** Adds an emoji to the next server-side batch when queue capacity remains. */
+export function enqueueEmoji(reaction: EmojiReaction): boolean {
+  const config = useRuntimeConfig()
+
+  if (emojiBuffer.length >= config.emojiQueueMaxSize) {
+    return false
+  }
+
+  emojiBuffer.push(reaction)
+  scheduleEmojiBatch()
+
+  return true
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,17 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite-plus'
 
+const rootDirectory = fileURLToPath(new URL('.', import.meta.url))
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      '#shared': resolve(rootDirectory, 'shared'),
+      '~': resolve(rootDirectory, 'app'),
+    },
+  },
+
   staged: {
     '**/*.{css,html,js,mjs,cjs,ts,mts,cts,vue,json,jsonc,yaml,yml,md}': [
       'vp exec eslint',


### PR DESCRIPTION
⚠️ **WebSocket emoji event contract changes:** Clients that consume the emojis channel must replace the singular `emoji` object handler with the `emojis` array handler before deployment.

This PR queues emoji reactions and broadcasts ordered batches over the emojis WebSocket channel. It adds server-side runtime controls with startup validation, client-side batch parsing and rendering, focused regression tests, and updated API and WebSocket documentation.

**feat**

- Queue validated emoji submissions in memory and broadcast ordered `emojis` arrays at a configured interval and batch size.
- Parse batch payloads on the emoji overlay and render every valid reaction.

**fix**

- Reject zero, negative, fractional, and nonnumeric emoji batching configuration during Nitro startup.

**test**

- Cover queue timing, batch rollover, queue capacity, route behavior, client payload parsing, and batching configuration validation.
- Add stable app and shared aliases to the Vite+ test configuration.

**docs**

- Document the batched WebSocket event and full-queue API behavior.

**chore**

- Expose server-side batch interval, batch size, and queue capacity settings through runtime configuration and `.env.example`.