### PR TITLE
feat: advance enabled question queue from active item

### DIFF
--- a/app/pages/admin/questions.vue
+++ b/app/pages/admin/questions.vue
@@ -66,6 +66,17 @@ function createQuestionFormFromQuestion(question: Question): QuestionForm {
   }
 }
 
+function getQueuePosition(question: Question, index: number): number | '-' {
+  if (question.is_disabled) {
+    return '-'
+  }
+
+  return allQuestions.value
+    .slice(0, index + 1)
+    .filter(item => !item.is_disabled)
+    .length
+}
+
 const activeQuestion = ref<Question | null>(null)
 const allQuestions = ref<Question[]>([])
 const questionDialog = ref<HTMLDialogElement>()
@@ -677,7 +688,7 @@ function removeOption(index: number) {
                   <tbody>
                     <tr class="border-b border-gray-300">
                       <th class="py-2 pr-4 text-left font-bold" scope="row">{{ t('queuePosition') }}</th>
-                      <td class="py-2 text-left">{{ index + 1 }}</td>
+                      <td class="py-2 text-left">{{ getQueuePosition(question, index) }}</td>
                     </tr>
                     <tr class="border-b border-gray-300">
                       <th class="py-2 pr-4 text-left font-bold" scope="row">{{ t('disabledStatus') }}</th>

--- a/docs/api.md
+++ b/docs/api.md
@@ -285,11 +285,11 @@ Publish question as active by key (admin only). Clears existing answers and broa
 
 ### POST `/api/questions/publish-next`
 
-Publish the next enabled, unpublished question in queue order (admin only). Finds the lowest `sortOrder` question where `alreadyPublished` and `is_disabled` are both `false`, publishes it, and broadcasts to all WebSocket clients.
+Publish the next enabled question after the active question in queue order (admin only). Previously published questions can be published again. Without an active question, it selects the first enabled question. It does not wrap after the last enabled question and broadcasts the selected question to all WebSocket clients.
 
 **Request:** No body required.
 
-**Response:** The published question object, or 404 if no enabled unpublished questions remain.
+**Response:** The published question object, or 404 with `quiz.no_enabled_question` if no enabled question can be selected.
 
 ### POST `/api/questions/move`
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -21,9 +21,11 @@ Configuration in `nuxt.config.ts`:
 - Admin credentials are read from runtime config and are not stored in SQLite.
 
 Question queue position is persisted in `questions.sort_order`. Admin and presenter
-question lists read this order, and `publish-next` selects the first unpublished,
-enabled question. `questions.is_disabled` skips a question only for automatic
-publication; direct admin publication remains available.
+question lists read this order, and `publish-next` selects the next enabled question
+after the active one. Previously published questions remain selectable. Without an
+active question, it starts with the first enabled question; after the last enabled
+question, it stops without wrapping. `questions.is_disabled` skips a question only
+for automatic publication; direct admin publication remains available.
 
 Changing a question's answer options after answers were submitted requires an explicit
 reset confirmation. The answers are deleted and the option update is stored in the

--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -31,7 +31,7 @@ export default defineI18nConfig(() => ({
           question_answers_reset_required: 'Changing answer options requires deleting submitted answers first.',
           question_active: 'Active questions cannot be edited.',
           question_published: 'Published questions cannot be edited.',
-          no_unpublished_question: 'No unpublished questions remain.',
+          no_enabled_question: 'No enabled question remains in the queue.',
           publish_next_failed: 'The next question could not be published.',
         },
         emoji: {
@@ -94,7 +94,7 @@ export default defineI18nConfig(() => ({
           question_answers_reset_required: 'Antwortoptionen ändern erfordert, zuerst abgegebene Antworten zu löschen.',
           question_active: 'Aktive Fragen können nicht bearbeitet werden.',
           question_published: 'Veröffentlichte Fragen können nicht bearbeitet werden.',
-          no_unpublished_question: 'Keine unveröffentlichten Fragen mehr vorhanden.',
+          no_enabled_question: 'Keine aktivierte Frage mehr in der Warteschlange.',
           publish_next_failed: 'Die nächste Frage konnte nicht veröffentlicht werden.',
         },
         emoji: {
@@ -157,7 +157,7 @@ export default defineI18nConfig(() => ({
           question_answers_reset_required: '回答項目を変更するには、送信済みの回答を先に削除する必要があります。',
           question_active: 'アクティブな質問は編集できません。',
           question_published: '公開済みの質問は編集できません。',
-          no_unpublished_question: '未公開の質問は残っていません。',
+          no_enabled_question: 'キュー内に有効な質問は残っていません。',
           publish_next_failed: '次の質問を公開できませんでした。',
         },
         emoji: {

--- a/server/api/questions/publish-next.post.ts
+++ b/server/api/questions/publish-next.post.ts
@@ -9,7 +9,7 @@ export default defineApiHandler(async (event) => {
   const nextQuestion = await getNextPublishableQuestion()
 
   if (!nextQuestion) {
-    throwApiError(404, 'quiz.no_unpublished_question')
+    throwApiError(404, 'quiz.no_enabled_question')
   }
 
   const question = await publishQuestion(nextQuestion.id)

--- a/server/api/response-contract.test.ts
+++ b/server/api/response-contract.test.ts
@@ -133,4 +133,10 @@ describe('POST response contract', () => {
     expect(source).toContain(answerResetBroadcast)
     expect(source.indexOf(answerResetBroadcast)).toBeLessThan(source.indexOf('if (question.is_active)'))
   })
+
+  it('uses the enabled-queue error code when no next question remains', async () => {
+    const source = await readSource('server/api/questions/publish-next.post.ts')
+
+    expect(source).toContain("throwApiError(404, 'quiz.no_enabled_question')")
+  })
 })

--- a/server/utils/storage.test.ts
+++ b/server/utils/storage.test.ts
@@ -65,11 +65,13 @@ function createInputQuestion(key: string) {
 beforeEach(() => {
   testClient = createLocalDatabaseClient(createTemporaryDatabasePath())
   applyLocalMigrations(testClient.db)
+  vi.stubGlobal('broadcast', vi.fn())
   globalThis.__stageFlowToolsLocalDatabaseClient = testClient
 })
 
 afterEach(() => {
   testClient.sqlite.close()
+  vi.unstubAllGlobals()
   globalThis.__stageFlowToolsLocalDatabaseClient = undefined
 
   for (const directory of temporaryDirectories.splice(0)) {
@@ -101,6 +103,27 @@ describe('question queue storage', () => {
       second.id,
     ])
     await expect(getNextPublishableQuestion()).resolves.toMatchObject({ id: third.id })
+  })
+
+  it('advances through enabled questions after the active question', async () => {
+    const first = await createQuestion(createInputQuestion('first'))
+    const disabled = await createQuestion(createInputQuestion('disabled'))
+    const third = await createQuestion(createInputQuestion('third'))
+
+    testClient.db.update(questions).set({ alreadyPublished: true }).where(eq(questions.id, first.id)).run()
+    testClient.db.update(questions).set({ alreadyPublished: true }).where(eq(questions.id, third.id)).run()
+    await toggleQuestionDisabled(disabled.id)
+
+    await expect(getNextPublishableQuestion()).resolves.toMatchObject({ id: first.id })
+
+    await publishQuestion(first.id)
+    await expect(getNextPublishableQuestion()).resolves.toMatchObject({ id: third.id })
+
+    await publishQuestion(disabled.id)
+    await expect(getNextPublishableQuestion()).resolves.toMatchObject({ id: third.id })
+
+    await publishQuestion(third.id)
+    await expect(getNextPublishableQuestion()).resolves.toBeUndefined()
   })
 
   it('deletes answers with their question and reports active deletion', async () => {

--- a/server/utils/storage.ts
+++ b/server/utils/storage.ts
@@ -268,9 +268,15 @@ export async function publishQuestion(questionIdentifier: string): Promise<Quest
   return publishedQuestion
 }
 
-/** Returns the first unpublished, enabled question in the persistent queue. */
+/** Returns the next enabled question after the active one in persistent queue order. */
 export async function getNextPublishableQuestion(): Promise<Question | undefined> {
-  return (await getQuestions()).find(question => !question.alreadyPublished && !question.is_disabled)
+  const questionList = await getQuestions()
+  const activeIndex = questionList.findIndex(question => question.is_active)
+  const followingQuestions = activeIndex < 0
+    ? questionList
+    : questionList.slice(activeIndex + 1)
+
+  return followingQuestions.find(question => !question.is_disabled)
 }
 
 /** Swaps a question with its adjacent queue item. */

--- a/shared/utils/api-errors.test.ts
+++ b/shared/utils/api-errors.test.ts
@@ -7,6 +7,7 @@ describe('isApiErrorCode', () => {
     expect(isApiErrorCode('validation.required')).toBe(true)
     expect(isApiErrorCode('quiz.question_not_found')).toBe(true)
     expect(isApiErrorCode('quiz.question_answers_reset_required')).toBe(true)
+    expect(isApiErrorCode('quiz.no_enabled_question')).toBe(true)
     expect(isApiErrorCode('Question not found')).toBe(false)
     expect(isApiErrorCode('unknown.code')).toBe(false)
   })

--- a/shared/utils/api-errors.ts
+++ b/shared/utils/api-errors.ts
@@ -18,7 +18,7 @@ export const API_ERROR_CODES = [
   'quiz.question_not_found',
   'quiz.question_key_conflict',
   'quiz.question_answers_reset_required',
-  'quiz.no_unpublished_question',
+  'quiz.no_enabled_question',
   'quiz.publish_next_failed',
   'emoji.cooldown',
   'answer.no_answers_for_question',


### PR DESCRIPTION
⚠️ **Publish-next error code changed:** API clients that match `quiz.no_unpublished_question` must switch to `quiz.no_enabled_question` before deployment; the old stable code is no longer emitted or recognized.

This PR advances automatic publication from the active question through the enabled queue and allows previously published questions to be selected again without wrapping. It aligns queue positions, API errors, translations, tests, and documentation with that behavior.

**fix**

- Select the next enabled question after the active queue item, or the first enabled item when no question is active.
- Allow automatic publication to select previously published questions and stop after the final enabled item.
- Replace the empty publish-next response code with `quiz.no_enabled_question` across the server error contract and translations.
- Show enabled-only queue positions and a dash for disabled questions in the admin question list.

**test**

- Cover queue progression across published, disabled, active, and exhausted states.
- Check the publish-next route's enabled-queue error code.

**docs**

- Document publish-next traversal, republication, non-wrapping behavior, and its empty-queue response.