### PR TITLE
feat: add configurable presentation display controls

### DIFF
--- a/app/composables/useDisplayParameters.test.ts
+++ b/app/composables/useDisplayParameters.test.ts
@@ -1,0 +1,57 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vite-plus/test'
+import {
+  DEFAULT_REFRESH_INTERVAL_SECONDS,
+  parseDisplayParameters,
+} from './useDisplayParameters'
+
+describe('parseDisplayParameters', () => {
+  it('parses the shared display contract', () => {
+    expect(parseDisplayParameters({
+      background: '#12aBcD',
+      core: '',
+      padding: '20',
+      refresh: '10',
+      scale: '0.9',
+      showUserId: 'false',
+      transparency: '0.4',
+    })).toEqual({
+      backgroundColor: '#12aBcD',
+      isCoreView: true,
+      padding: 20,
+      refreshIntervalMs: 10000,
+      scale: 0.9,
+      showUserId: false,
+      transparency: 0.4,
+    })
+  })
+
+  it('uses safe defaults for missing or invalid values', () => {
+    expect(parseDisplayParameters({
+      background: '#12345',
+      padding: '-1',
+      refresh: '-1',
+      scale: '0',
+      showUserId: 'no',
+      transparency: '2',
+    })).toEqual({
+      backgroundColor: undefined,
+      isCoreView: false,
+      padding: 0,
+      refreshIntervalMs: DEFAULT_REFRESH_INTERVAL_SECONDS * 1000,
+      scale: 1,
+      showUserId: true,
+      transparency: 1,
+    })
+  })
+
+  it('allows refresh to be disabled without changing the other defaults', () => {
+    expect(parseDisplayParameters({ refresh: '0' })).toMatchObject({
+      refreshIntervalMs: 0,
+      showUserId: true,
+    })
+  })
+})

--- a/app/composables/useDisplayParameters.test.ts
+++ b/app/composables/useDisplayParameters.test.ts
@@ -62,6 +62,12 @@ describe('parseDisplayParameters', () => {
     })
   })
 
+  it('clamps transparency to the documented range', () => {
+    expect(parseDisplayParameters({ transparency: '-0.5' })).toMatchObject({
+      transparency: 0,
+    })
+  })
+
   it('allows refresh to be disabled without changing the other defaults', () => {
     expect(parseDisplayParameters({ refresh: '0' })).toMatchObject({
       refreshIntervalMs: 0,

--- a/app/composables/useDisplayParameters.test.ts
+++ b/app/composables/useDisplayParameters.test.ts
@@ -48,6 +48,20 @@ describe('parseDisplayParameters', () => {
     })
   })
 
+  it('uses defaults for blank numeric values', () => {
+    expect(parseDisplayParameters({
+      padding: '',
+      refresh: '  ',
+      scale: '',
+      transparency: '',
+    })).toMatchObject({
+      padding: 0,
+      refreshIntervalMs: DEFAULT_REFRESH_INTERVAL_SECONDS * 1000,
+      scale: 1,
+      transparency: 1,
+    })
+  })
+
   it('allows refresh to be disabled without changing the other defaults', () => {
     expect(parseDisplayParameters({ refresh: '0' })).toMatchObject({
       refreshIntervalMs: 0,

--- a/app/composables/useDisplayParameters.ts
+++ b/app/composables/useDisplayParameters.ts
@@ -56,7 +56,7 @@ function parseBackgroundColor(value: string | undefined): string | undefined {
 
 /** Parses shared, presentation-oriented query parameters. */
 export function parseDisplayParameters(query: DisplayQuery): DisplayParameters {
-  const transparency = parseNonNegativeNumber(getSingleQueryValue(query, 'transparency'), 1)
+  const transparency = parseNumber(getSingleQueryValue(query, 'transparency'), 1)
 
   return {
     backgroundColor: parseBackgroundColor(getSingleQueryValue(query, 'background')),
@@ -65,7 +65,7 @@ export function parseDisplayParameters(query: DisplayQuery): DisplayParameters {
     refreshIntervalMs: parseRefreshInterval(getSingleQueryValue(query, 'refresh')),
     scale: parsePositiveNumber(getSingleQueryValue(query, 'scale'), 1),
     showUserId: getSingleQueryValue(query, 'showUserId') !== 'false',
-    transparency: Math.min(transparency, 1),
+    transparency: Math.min(Math.max(transparency, 0), 1),
   }
 }
 

--- a/app/composables/useDisplayParameters.ts
+++ b/app/composables/useDisplayParameters.ts
@@ -1,0 +1,103 @@
+import type { CSSProperties } from 'vue'
+
+export const DEFAULT_REFRESH_INTERVAL_SECONDS = 5
+
+type DisplayQuery = Record<string, unknown>
+
+export type DisplayParameters = {
+  backgroundColor?: string
+  isCoreView: boolean
+  padding: number
+  refreshIntervalMs: number
+  scale: number
+  showUserId: boolean
+  transparency: number
+}
+
+function getSingleQueryValue(query: DisplayQuery, key: string): string | undefined {
+  const value = query[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+function parseNumber(value: string | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback
+  }
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function parsePositiveNumber(value: string | undefined, fallback: number): number {
+  const parsed = parseNumber(value, fallback)
+  return parsed > 0 ? parsed : fallback
+}
+
+function parseNonNegativeNumber(value: string | undefined, fallback: number): number {
+  const parsed = parseNumber(value, fallback)
+  return parsed >= 0 ? parsed : fallback
+}
+
+function parseRefreshInterval(value: string | undefined): number {
+  const seconds = parseNumber(value, DEFAULT_REFRESH_INTERVAL_SECONDS)
+
+  if (!Number.isInteger(seconds) || seconds < 0) {
+    return DEFAULT_REFRESH_INTERVAL_SECONDS * 1000
+  }
+
+  return seconds * 1000
+}
+
+function parseBackgroundColor(value: string | undefined): string | undefined {
+  return value && /^#[\dA-Fa-f]{6}$/.test(value)
+    ? value
+    : undefined
+}
+
+/** Parses shared, presentation-oriented query parameters. */
+export function parseDisplayParameters(query: DisplayQuery): DisplayParameters {
+  const transparency = parseNonNegativeNumber(getSingleQueryValue(query, 'transparency'), 1)
+
+  return {
+    backgroundColor: parseBackgroundColor(getSingleQueryValue(query, 'background')),
+    isCoreView: query.core !== undefined,
+    padding: parseNonNegativeNumber(getSingleQueryValue(query, 'padding'), 0),
+    refreshIntervalMs: parseRefreshInterval(getSingleQueryValue(query, 'refresh')),
+    scale: parsePositiveNumber(getSingleQueryValue(query, 'scale'), 1),
+    showUserId: getSingleQueryValue(query, 'showUserId') !== 'false',
+    transparency: Math.min(transparency, 1),
+  }
+}
+
+/** Exposes reactive display query parameters for authenticated presentation pages. */
+export function useDisplayParameters() {
+  const route = useRoute()
+  const parameters = computed(() => parseDisplayParameters(route.query))
+
+  const coreViewStyles = computed<CSSProperties>(() => {
+    if (!parameters.value.isCoreView) {
+      return {}
+    }
+
+    return {
+      padding: `${parameters.value.padding}px`,
+      transform: `scale(${parameters.value.scale})`,
+      transformOrigin: 'top left',
+      width: `calc(100% / ${parameters.value.scale})`,
+    }
+  })
+
+  const backgroundStyles = computed<CSSProperties>(() => parameters.value.backgroundColor
+    ? { backgroundColor: parameters.value.backgroundColor }
+    : {})
+
+  return {
+    backgroundStyles,
+    coreViewStyles,
+    isCoreView: computed(() => parameters.value.isCoreView),
+    refreshIntervalMs: computed(() => parameters.value.refreshIntervalMs),
+    scale: computed(() => parameters.value.scale),
+    showUserId: computed(() => parameters.value.showUserId),
+    transparency: computed(() => parameters.value.transparency),
+  }
+}

--- a/app/composables/useDisplayParameters.ts
+++ b/app/composables/useDisplayParameters.ts
@@ -20,7 +20,7 @@ function getSingleQueryValue(query: DisplayQuery, key: string): string | undefin
 }
 
 function parseNumber(value: string | undefined, fallback: number): number {
-  if (value === undefined) {
+  if (value === undefined || value.trim() === '') {
     return fallback
   }
 

--- a/app/pages/admin/emojis.test.ts
+++ b/app/pages/admin/emojis.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import {
+  computed,
+  createApp,
+  nextTick,
+  ref,
+  watch,
+} from 'vue'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vite-plus/test'
+import EmojisPage from './emojis.vue'
+
+const route = {
+  query: {} as Record<string, string>,
+}
+
+function renderPage() {
+  const container = document.createElement('div')
+  const app = createApp(EmojisPage)
+  document.body.append(container)
+  app.mount(container)
+
+  return { app, container }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('computed', computed)
+  vi.stubGlobal('definePageMeta', vi.fn())
+  vi.stubGlobal('getWsEndpoint', () => 'ws://localhost/_ws')
+  vi.stubGlobal('logger_error', vi.fn())
+  vi.stubGlobal('onMounted', (callback: () => void) => callback())
+  vi.stubGlobal('ref', ref)
+  vi.stubGlobal('requestAnimationFrame', vi.fn())
+  vi.stubGlobal('useRoute', () => route)
+  vi.stubGlobal('useWebSocket', () => ({ data: ref('') }))
+  vi.stubGlobal('useWindowSize', () => ({ height: ref(768), width: ref(1024) }))
+  vi.stubGlobal('watch', watch)
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+  route.query = {}
+  vi.unstubAllGlobals()
+})
+
+describe('emoji display background', () => {
+  it('uses a valid background color', async () => {
+    route.query = { background: '#123456' }
+    const rendered = renderPage()
+    await nextTick()
+
+    const display = rendered.container.firstElementChild as HTMLElement
+    expect(display.style.backgroundColor).toBe('rgb(18, 52, 86)')
+
+    rendered.app.unmount()
+  })
+
+  it('keeps the transparent default without a background parameter', async () => {
+    const rendered = renderPage()
+    await nextTick()
+
+    const display = rendered.container.firstElementChild as HTMLElement
+    expect(display.style.backgroundColor).toBe('')
+
+    rendered.app.unmount()
+  })
+})

--- a/app/pages/admin/emojis.vue
+++ b/app/pages/admin/emojis.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useDisplayParameters } from '~/composables/useDisplayParameters'
 import { getEmojiBatch } from '~/utils/emoji-batch'
 
 definePageMeta({
@@ -21,12 +22,11 @@ interface Emoji {
 const emojis = ref<Emoji[]>([])
 const { width: windowWidth, height: windowHeight } = useWindowSize()
 
-const route = useRoute()
-const scale = computed(() => Number(route.query.scale) || 1)
-const transparency = computed(() => {
-  const val = Number(route.query.transparency) || 1
-  return Math.min(val, 1)
-})
+const {
+  backgroundStyles,
+  scale,
+  transparency,
+} = useDisplayParameters()
 
 // WebSocket connection
 const wsEndpoint = computed(() => getWsEndpoint('default', { channel: 'emojis' }))
@@ -78,7 +78,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="fixed inset-0 overflow-hidden">
+  <div class="fixed inset-0 overflow-hidden" :style="backgroundStyles">
     <div
       v-for="emoji in emojis"
       :key="emoji.id"

--- a/app/pages/admin/leaderboard.test.ts
+++ b/app/pages/admin/leaderboard.test.ts
@@ -206,6 +206,34 @@ describe('leaderboard display mode', () => {
     rendered.app.unmount()
   })
 
+  it('keeps the last successful leaderboard visible during failed background refreshes', async () => {
+    vi.useFakeTimers()
+    let rejectRefresh: (reason?: unknown) => void
+    const pendingRefresh = new Promise<typeof initialResponse>((_resolve, reject) => {
+      rejectRefresh = reject
+    })
+    const fetchLeaderboard = vi.fn()
+      .mockResolvedValueOnce(initialResponse)
+      .mockReturnValueOnce(pendingRefresh)
+    vi.stubGlobal('$fetch', fetchLeaderboard)
+
+    const rendered = renderPage()
+    await flushAsyncState()
+    await vi.advanceTimersByTimeAsync(5000)
+    await nextTick()
+
+    expect(rendered.container.textContent).toContain('Alice')
+    expect(rendered.container.textContent).not.toContain('loading')
+
+    rejectRefresh!(new Error('Network error'))
+    await flushAsyncState()
+
+    expect(rendered.container.textContent).toContain('Alice')
+    expect(rendered.container.textContent).not.toContain('error')
+
+    rendered.app.unmount()
+  })
+
   it('does not start a second polling request while one is still loading', async () => {
     vi.useFakeTimers()
     let resolveFetch: (response: typeof initialResponse) => void

--- a/app/pages/admin/leaderboard.test.ts
+++ b/app/pages/admin/leaderboard.test.ts
@@ -51,6 +51,18 @@ const Passthrough = defineComponent({
   },
 })
 
+const Icon = defineComponent({
+  props: {
+    name: {
+      required: true,
+      type: String,
+    },
+  },
+  setup(props) {
+    return () => h('svg', { 'data-icon': props.name })
+  },
+})
+
 const initialResponse = {
   leaderboard: [
     {
@@ -79,7 +91,7 @@ const refreshedResponse = {
 
 function findButton(container: ParentNode, label: string): HTMLButtonElement {
   const button = Array.from(container.querySelectorAll('button'))
-    .find(candidate => candidate.textContent === label)
+    .find(candidate => candidate.textContent?.includes(label))
 
   if (!button) {
     throw new Error(`Button "${label}" is missing`)
@@ -98,6 +110,7 @@ function renderPage() {
   const container = document.createElement('div')
   const app = createApp(LeaderboardPage)
   app.component('UiButton', UiButton)
+  app.component('Icon', Icon)
   app.component('UiPageTitle', Passthrough)
   app.component('UiSection', Passthrough)
   document.body.append(container)
@@ -153,11 +166,23 @@ describe('leaderboard display mode', () => {
     const rendered = renderPage()
     await flushAsyncState()
 
-    expect(rendered.container.textContent).toContain('drawWinner')
-    expect(rendered.container.textContent).toContain('over9000')
+    const drawWinnerButton = findButton(rendered.container, 'drawWinner')
+    const over9000Button = findButton(rendered.container, '🐉')
+    const userIdVisibilityButton = findButton(rendered.container, 'showUserIds')
+    const refreshButton = findButton(rendered.container, 'refresh')
+
+    expect(drawWinnerButton.textContent).toContain('🏆')
+    expect(over9000Button.textContent?.trim()).toBe('🐉')
+    expect(over9000Button.getAttribute('aria-label')).toBe('over9000')
+    expect(refreshButton.querySelector('[data-icon="ph:arrow-clockwise"]')).not.toBeNull()
     expect(rendered.container.textContent).toContain('refresh')
     expect(rendered.container.textContent).not.toContain('alice-id')
     expect((rendered.container.firstElementChild as HTMLElement).style.backgroundColor).toBe('rgb(18, 52, 86)')
+
+    userIdVisibilityButton.click()
+    await nextTick()
+    expect(rendered.container.textContent).toContain('alice-id')
+    expect(rendered.container.textContent).toContain('hideUserIds')
 
     rendered.app.unmount()
   })

--- a/app/pages/admin/leaderboard.test.ts
+++ b/app/pages/admin/leaderboard.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+import {
+  computed,
+  createApp,
+  defineComponent,
+  h,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+} from 'vue'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vite-plus/test'
+import LeaderboardPage from './leaderboard.vue'
+
+vi.mock('canvas-confetti', () => {
+  const instance = Object.assign(vi.fn(), { reset: vi.fn() })
+  const confetti = Object.assign(vi.fn(), {
+    create: vi.fn(() => instance),
+  })
+
+  return { default: confetti }
+})
+
+vi.mock('~/utils/pickRandomItem', () => ({
+  pickRandomItem: <T>(items: T[]) => items[0],
+}))
+
+const route = {
+  query: {} as Record<string, string>,
+}
+
+const UiButton = defineComponent({
+  inheritAttrs: false,
+  setup(_props, { attrs, slots }) {
+    return () => h('button', attrs, slots.default?.())
+  },
+})
+
+const Passthrough = defineComponent({
+  inheritAttrs: false,
+  setup(_props, { attrs, slots }) {
+    return () => h('div', attrs, slots.default?.())
+  },
+})
+
+const initialResponse = {
+  leaderboard: [
+    {
+      correctAnswers: 3,
+      nickname: 'Alice',
+      rank: 1,
+      userId: 'alice-id',
+    },
+  ],
+  totalPublishedQuestions: 3,
+  totalQuestionsWithCorrectAnswers: 3,
+}
+
+const refreshedResponse = {
+  leaderboard: [
+    {
+      correctAnswers: 4,
+      nickname: 'Bob',
+      rank: 1,
+      userId: 'bob-id',
+    },
+  ],
+  totalPublishedQuestions: 10,
+  totalQuestionsWithCorrectAnswers: 10,
+}
+
+function findButton(container: ParentNode, label: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button'))
+    .find(candidate => candidate.textContent === label)
+
+  if (!button) {
+    throw new Error(`Button "${label}" is missing`)
+  }
+
+  return button
+}
+
+async function flushAsyncState() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await nextTick()
+}
+
+function renderPage() {
+  const container = document.createElement('div')
+  const app = createApp(LeaderboardPage)
+  app.component('UiButton', UiButton)
+  app.component('UiPageTitle', Passthrough)
+  app.component('UiSection', Passthrough)
+  document.body.append(container)
+  app.mount(container)
+
+  return { app, container }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('computed', computed)
+  vi.stubGlobal('definePageMeta', vi.fn())
+  vi.stubGlobal('logger_error', vi.fn())
+  vi.stubGlobal('nextTick', nextTick)
+  vi.stubGlobal('onBeforeUnmount', onBeforeUnmount)
+  vi.stubGlobal('onMounted', onMounted)
+  vi.stubGlobal('ref', ref)
+  vi.stubGlobal('useI18n', () => ({ t: (key: string) => key }))
+  vi.stubGlobal('useRoute', () => route)
+  vi.stubGlobal('watch', watch)
+
+  Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
+    configurable: true,
+    value() {
+      this.setAttribute('open', '')
+    },
+  })
+  Object.defineProperty(HTMLDialogElement.prototype, 'close', {
+    configurable: true,
+    value() {
+      this.removeAttribute('open')
+      this.dispatchEvent(new Event('close'))
+    },
+  })
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+  route.query = {}
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('leaderboard display mode', () => {
+  it('keeps controls available and hides IDs only when requested', async () => {
+    vi.stubGlobal('$fetch', vi.fn().mockResolvedValue(initialResponse))
+    route.query = {
+      background: '#123456',
+      core: '',
+      refresh: '0',
+      showUserId: 'false',
+    }
+
+    const rendered = renderPage()
+    await flushAsyncState()
+
+    expect(rendered.container.textContent).toContain('drawWinner')
+    expect(rendered.container.textContent).toContain('over9000')
+    expect(rendered.container.textContent).toContain('refresh')
+    expect(rendered.container.textContent).not.toContain('alice-id')
+    expect((rendered.container.firstElementChild as HTMLElement).style.backgroundColor).toBe('rgb(18, 52, 86)')
+
+    rendered.app.unmount()
+  })
+
+  it('refreshes leaderboard data every five seconds without reloading the page', async () => {
+    vi.useFakeTimers()
+    const fetchLeaderboard = vi.fn().mockResolvedValue(initialResponse)
+    vi.stubGlobal('$fetch', fetchLeaderboard)
+
+    const rendered = renderPage()
+    await flushAsyncState()
+    expect(fetchLeaderboard).toHaveBeenCalledTimes(1)
+    expect(rendered.container.textContent).toContain('alice-id')
+
+    await vi.advanceTimersByTimeAsync(5000)
+    await flushAsyncState()
+
+    expect(fetchLeaderboard).toHaveBeenCalledTimes(2)
+    expect(rendered.container.textContent).toContain('alice-id')
+
+    rendered.app.unmount()
+  })
+
+  it('does not start a second polling request while one is still loading', async () => {
+    vi.useFakeTimers()
+    let resolveFetch: (response: typeof initialResponse) => void
+    const pendingResponse = new Promise<typeof initialResponse>((resolve) => {
+      resolveFetch = resolve
+    })
+    const fetchLeaderboard = vi.fn().mockReturnValue(pendingResponse)
+    vi.stubGlobal('$fetch', fetchLeaderboard)
+
+    const rendered = renderPage()
+    await flushAsyncState()
+    await vi.advanceTimersByTimeAsync(10000)
+
+    expect(fetchLeaderboard).toHaveBeenCalledTimes(1)
+
+    resolveFetch!(initialResponse)
+    await flushAsyncState()
+    rendered.app.unmount()
+  })
+
+  it('keeps a selected winner unchanged after the table refreshes', async () => {
+    vi.useFakeTimers()
+    const fetchLeaderboard = vi.fn()
+      .mockResolvedValueOnce(initialResponse)
+      .mockResolvedValueOnce(refreshedResponse)
+    vi.stubGlobal('$fetch', fetchLeaderboard)
+    route.query = { refresh: '0' }
+
+    const rendered = renderPage()
+    await flushAsyncState()
+
+    findButton(rendered.container, 'drawWinner').click()
+    await nextTick()
+    const dialog = rendered.container.querySelector('dialog') as HTMLDialogElement
+    findButton(dialog, 'drawWinner').click()
+    await nextTick()
+
+    findButton(rendered.container, 'refresh').click()
+    await flushAsyncState()
+    await vi.advanceTimersByTimeAsync(750)
+    await flushAsyncState()
+
+    expect(dialog.open).toBe(true)
+    expect(dialog.textContent).toContain('Alice')
+    expect(dialog.textContent).toContain('/ 3')
+    expect(rendered.container.textContent).toContain('Bob')
+
+    rendered.app.unmount()
+  })
+})

--- a/app/pages/admin/leaderboard.vue
+++ b/app/pages/admin/leaderboard.vue
@@ -16,7 +16,7 @@ const {
   coreViewStyles,
   isCoreView,
   refreshIntervalMs,
-  showUserId,
+  showUserId: initialShowUserId,
 } = useDisplayParameters()
 
 interface LeaderboardEntry {
@@ -39,6 +39,7 @@ type ConfettiInstance = ReturnType<ConfettiModule['default']['create']>
 const isLoading = ref(false)
 const hasError = ref(false)
 const isOver9000Mode = ref(false)
+const showUserId = ref(initialShowUserId.value)
 const leaderboard = ref<LeaderboardEntry[]>([])
 const totalPublishedQuestions = ref(0)
 const totalQuestionsWithCorrectAnswers = ref(0)
@@ -57,6 +58,10 @@ const topRankedEntries = computed(() => leaderboard.value.filter(entry => entry.
 
 function toggleOver9000Mode() {
   isOver9000Mode.value = !isOver9000Mode.value
+}
+
+function toggleUserIdVisibility() {
+  showUserId.value = !showUserId.value
 }
 
 function clearWinnerTimer() {
@@ -271,29 +276,41 @@ watch(refreshIntervalMs, restartPolling)
         <p class="text-sm text-gray-500">
           {{ t('scoredQuestions', { count: totalQuestionsWithCorrectAnswers }) }}
         </p>
-        <div class="flex gap-2">
+        <div class="flex flex-wrap gap-2">
           <UiButton
+            class="inline-flex items-center gap-2"
             :disabled="isLoading || isWinnerModalOpen || topRankedEntries.length === 0"
             size="small"
             @click="openWinnerModal"
           >
+            <span aria-hidden="true">🏆</span>
             {{ t('drawWinner') }}
           </UiButton>
           <UiButton
+            :aria-label="isOver9000Mode ? t('showScores') : t('over9000')"
             :aria-pressed="isOver9000Mode"
             :disabled="isLoading || leaderboard.length === 0"
             size="small"
             :variant="isOver9000Mode ? 'primary' : 'secondary'"
             @click="toggleOver9000Mode"
           >
-            {{ isOver9000Mode ? t('showScores') : t('over9000') }}
+            <span aria-hidden="true">🐉</span>
           </UiButton>
           <UiButton
+            size="small"
+            variant="secondary"
+            @click="toggleUserIdVisibility"
+          >
+            {{ showUserId ? t('hideUserIds') : t('showUserIds') }}
+          </UiButton>
+          <UiButton
+            class="inline-flex items-center gap-2"
             :disabled="isLoading"
             size="small"
             variant="secondary"
             @click="fetchLeaderboard"
           >
+            <Icon aria-hidden="true" class="size-4" name="ph:arrow-clockwise" />
             {{ t('refresh') }}
           </UiButton>
         </div>
@@ -469,6 +486,8 @@ en:
   drawWinner: Draw winner
   over9000: 🐉 Over 9000!
   showScores: 🐉 Show scores
+  showUserIds: Show IDs
+  hideUserIds: Hide IDs
   winner: Winner
   winnerDrawHint: The person with the most correct answers will be drawn. Ties are decided at random.
   drawingWinner: Drawing winner...
@@ -486,6 +505,8 @@ de:
   drawWinner: Gewinner ziehen
   over9000: 🐉 Über 9000!
   showScores: 🐉 Punkte zeigen
+  showUserIds: IDs zeigen
+  hideUserIds: IDs ausblenden
   winner: Gewinner
   winnerDrawHint: Die Person mit den meisten richtigen Antworten wird gezogen. Bei Gleichstand entscheidet der Zufall.
   drawingWinner: Auslosung läuft...
@@ -503,6 +524,8 @@ ja:
   drawWinner: 当選者を選ぶ
   over9000: 🐉 9000以上！
   showScores: 🐉 得点を表示
+  showUserIds: IDを表示
+  hideUserIds: IDを非表示
   winner: 当選者
   winnerDrawHint: 最も多く正解した参加者から選びます。同点の場合はランダムに選ばれます。
   drawingWinner: 抽選中...

--- a/app/pages/admin/leaderboard.vue
+++ b/app/pages/admin/leaderboard.vue
@@ -38,6 +38,7 @@ type ConfettiInstance = ReturnType<ConfettiModule['default']['create']>
 
 const isLoading = ref(false)
 const hasError = ref(false)
+const hasLoadedLeaderboard = ref(false)
 const isOver9000Mode = ref(false)
 const showUserId = ref(initialShowUserId.value)
 const leaderboard = ref<LeaderboardEntry[]>([])
@@ -211,19 +212,23 @@ async function fetchLeaderboard() {
   }
 
   isLoading.value = true
-  hasError.value = false
+  if (!hasLoadedLeaderboard.value) {
+    hasError.value = false
+  }
+
   try {
     const data = await $fetch<LeaderboardResponse>('/api/results/leaderboard')
     leaderboard.value = data.leaderboard
     totalPublishedQuestions.value = data.totalPublishedQuestions
     totalQuestionsWithCorrectAnswers.value = data.totalQuestionsWithCorrectAnswers
+    hasLoadedLeaderboard.value = true
+    hasError.value = false
   }
   catch (error: unknown) {
     logger_error('Failed to fetch leaderboard', error)
-    hasError.value = true
-    leaderboard.value = []
-    totalPublishedQuestions.value = 0
-    totalQuestionsWithCorrectAnswers.value = 0
+    if (!hasLoadedLeaderboard.value) {
+      hasError.value = true
+    }
   }
   finally {
     isLoading.value = false
@@ -317,7 +322,7 @@ watch(refreshIntervalMs, restartPolling)
       </div>
 
       <UiSection :bare="isCoreView">
-        <p v-if="isLoading" class="status-message">
+        <p v-if="isLoading && !hasLoadedLeaderboard" class="status-message">
           {{ t('loading') }}
         </p>
 

--- a/app/pages/admin/leaderboard.vue
+++ b/app/pages/admin/leaderboard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useDisplayParameters } from '~/composables/useDisplayParameters'
 import { pickRandomItem } from '~/utils/pickRandomItem'
 
 definePageMeta({
@@ -10,6 +11,13 @@ definePageMeta({
 })
 
 const { t } = useI18n()
+const {
+  backgroundStyles,
+  coreViewStyles,
+  isCoreView,
+  refreshIntervalMs,
+  showUserId,
+} = useDisplayParameters()
 
 interface LeaderboardEntry {
   rank: number
@@ -37,9 +45,11 @@ const totalQuestionsWithCorrectAnswers = ref(0)
 const isWinnerModalOpen = ref(false)
 const winnerModalPhase = ref<WinnerModalPhase>('ready')
 const selectedWinner = ref<LeaderboardEntry>()
+const selectedWinnerTotalPublishedQuestions = ref(0)
 const winnerDialog = ref<HTMLDialogElement>()
 const winnerConfettiCanvas = ref<HTMLCanvasElement>()
 let winnerTimer: ReturnType<typeof setTimeout> | undefined
+let refreshTimer: ReturnType<typeof setInterval> | undefined
 let confettiModule: Promise<ConfettiModule> | undefined
 let winnerConfetti: ConfettiInstance | undefined
 
@@ -143,6 +153,7 @@ function resetWinnerModal() {
   isWinnerModalOpen.value = false
   winnerModalPhase.value = 'ready'
   selectedWinner.value = undefined
+  selectedWinnerTotalPublishedQuestions.value = 0
 }
 
 function closeWinnerModal() {
@@ -165,11 +176,16 @@ function openWinnerModal() {
 function startWinnerDraw() {
   if (winnerModalPhase.value !== 'ready') return
 
+  const candidates = [
+    ...topRankedEntries.value,
+  ]
+  const totalPublishedQuestionsAtDrawStart = totalPublishedQuestions.value
+
   winnerModalPhase.value = 'drawing'
   preloadConfetti()
   winnerTimer = setTimeout(() => {
     winnerTimer = undefined
-    const winner = pickRandomItem(topRankedEntries.value)
+    const winner = pickRandomItem(candidates)
 
     if (!winner) {
       closeWinnerModal()
@@ -177,6 +193,7 @@ function startWinnerDraw() {
     }
 
     selectedWinner.value = winner
+    selectedWinnerTotalPublishedQuestions.value = totalPublishedQuestionsAtDrawStart
     winnerModalPhase.value = 'revealed'
     void celebrateWinner()
   }, 750)
@@ -184,7 +201,10 @@ function startWinnerDraw() {
 
 /** Fetch leaderboard data from the API. */
 async function fetchLeaderboard() {
-  closeWinnerModal()
+  if (isLoading.value) {
+    return
+  }
+
   isLoading.value = true
   hasError.value = false
   try {
@@ -205,195 +225,238 @@ async function fetchLeaderboard() {
   }
 }
 
+function stopPolling() {
+  if (refreshTimer === undefined) {
+    return
+  }
+
+  clearInterval(refreshTimer)
+  refreshTimer = undefined
+}
+
+function restartPolling() {
+  stopPolling()
+
+  if (refreshIntervalMs.value === 0) {
+    return
+  }
+
+  refreshTimer = setInterval(() => {
+    void fetchLeaderboard()
+  }, refreshIntervalMs.value)
+}
+
 onMounted(() => {
-  fetchLeaderboard()
+  void fetchLeaderboard()
+  restartPolling()
 })
 
 onBeforeUnmount(() => {
+  stopPolling()
   clearWinnerTimer()
   clearWinnerConfetti()
 })
+
+watch(refreshIntervalMs, restartPolling)
 </script>
 
 <template>
-  <div class="mx-auto max-w-3xl p-5">
-    <UiPageTitle>{{ t('title') }}</UiPageTitle>
+  <div class="min-h-screen" :style="backgroundStyles">
+    <div :class="isCoreView ? 'min-h-screen' : 'mx-auto max-w-3xl p-5'" :style="coreViewStyles">
+      <UiPageTitle v-if="!isCoreView">
+        {{ t('title') }}
+      </UiPageTitle>
 
-    <div class="mb-5 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
-      <p class="text-sm text-gray-500">
-        {{ t('scoredQuestions', { count: totalQuestionsWithCorrectAnswers }) }}
-      </p>
-      <div class="flex gap-2">
-        <UiButton
-          :disabled="isLoading || isWinnerModalOpen || topRankedEntries.length === 0"
-          size="small"
-          @click="openWinnerModal"
-        >
-          {{ t('drawWinner') }}
-        </UiButton>
-        <UiButton
-          :aria-pressed="isOver9000Mode"
-          :disabled="isLoading || leaderboard.length === 0"
-          size="small"
-          :variant="isOver9000Mode ? 'primary' : 'secondary'"
-          @click="toggleOver9000Mode"
-        >
-          {{ isOver9000Mode ? t('showScores') : t('over9000') }}
-        </UiButton>
-        <UiButton
-          :disabled="isLoading"
-          size="small"
-          variant="secondary"
-          @click="fetchLeaderboard"
-        >
-          {{ t('refresh') }}
-        </UiButton>
-      </div>
-    </div>
-
-    <UiSection>
-      <p v-if="isLoading" class="status-message">
-        {{ t('loading') }}
-      </p>
-
-      <p
-        v-else-if="hasError"
-        class="status-message"
-      >
-        {{ t('error') }}
-      </p>
-
-      <p
-        v-else-if="leaderboard.length === 0"
-        class="status-message"
-      >
-        {{ t('empty') }}
-      </p>
-
-      <table v-else class="w-full border-collapse">
-        <thead>
-          <tr class="border-b-[3px] border-black text-left tracking-wide uppercase">
-            <th class="p-3 text-center">
-              {{ t('rank') }}
-            </th>
-            <th class="p-3">
-              {{ t('player') }}
-            </th>
-            <th class="p-3 text-center">
-              {{ t('correctAnswers') }}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            v-for="entry in leaderboard"
-            :key="entry.userId"
-            class="border-b border-gray-300"
-          >
-            <td class="p-3 text-center text-xl font-bold">
-              {{ entry.rank }}
-            </td>
-            <td class="p-3">
-              {{ entry.nickname }}
-              <span class="ml-1 text-xs text-gray-400">({{ entry.userId }})</span>
-            </td>
-            <td class="p-3 text-center text-xl font-bold">
-              {{ isOver9000Mode ? '>9000' : entry.correctAnswers }}
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </UiSection>
-
-    <dialog
-      v-if="isWinnerModalOpen"
-      ref="winnerDialog"
-      :aria-busy="winnerModalPhase === 'drawing'"
-      :aria-describedby="winnerModalPhase === 'ready' ? 'winner-modal-description' : undefined"
-      aria-labelledby="winner-modal-title"
-      class="m-auto max-h-[calc(100dvh-2.5rem)] w-[calc(100%-2.5rem)] max-w-md
-        border-[3px] border-black bg-white p-6 text-black backdrop:bg-black/50"
-      @click.self="closeWinnerModal"
-      @close="resetWinnerModal"
-    >
-      <canvas
-        ref="winnerConfettiCanvas"
-        aria-hidden="true"
-        class="pointer-events-none fixed inset-0 z-10 h-dvh w-dvw"
-      />
-
-      <div class="relative z-20">
-        <p class="text-sm font-bold tracking-wide uppercase">
-          {{ t('winner') }}
+      <div class="mb-5 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p class="text-sm text-gray-500">
+          {{ t('scoredQuestions', { count: totalQuestionsWithCorrectAnswers }) }}
         </p>
-
-        <template v-if="winnerModalPhase === 'ready'">
-          <h2 id="winner-modal-title" class="mt-2 text-4xl leading-tight font-bold">
+        <div class="flex gap-2">
+          <UiButton
+            :disabled="isLoading || isWinnerModalOpen || topRankedEntries.length === 0"
+            size="small"
+            @click="openWinnerModal"
+          >
             {{ t('drawWinner') }}
-          </h2>
-
-          <div class="mt-6">
-            <UiButton @click="startWinnerDraw">
-              {{ t('drawWinner') }}
-            </UiButton>
-            <p id="winner-modal-description" class="mt-3 text-sm text-gray-600">
-              {{ t('winnerDrawHint') }}
-            </p>
-          </div>
-        </template>
-
-        <template v-else-if="winnerModalPhase === 'drawing'">
-          <h2 id="winner-modal-title" class="mt-2 text-4xl leading-tight font-bold">
-            {{ t('drawingWinner') }}
-          </h2>
-
-          <div aria-live="polite" class="mt-6 border-[3px] border-black bg-gray-100 p-8 text-center" role="status">
-            <div
-              aria-hidden="true"
-              class="mx-auto size-16 animate-spin border-[6px] border-black border-t-gray-300
-                motion-reduce:animate-none"
-            />
-            <p class="mt-4 text-sm font-bold tracking-wide uppercase">
-              {{ t('drawingWinner') }}
-            </p>
-          </div>
-        </template>
-
-        <template v-else-if="selectedWinner">
-          <h2 id="winner-modal-title" class="mt-2 text-4xl leading-tight font-bold">
-            {{ selectedWinner.nickname }}
-          </h2>
-
-          <dl class="mt-6 grid grid-cols-2 gap-3">
-            <div class="winner-stat">
-              <dt class="winner-stat-label">
-                {{ t('rank') }}
-              </dt>
-              <dd class="winner-stat-value">
-                {{ selectedWinner.rank }}
-              </dd>
-            </div>
-            <div class="winner-stat">
-              <dt class="winner-stat-label">
-                {{ t('correctAnswers') }}
-              </dt>
-              <dd class="winner-stat-value">
-                {{ selectedWinner.correctAnswers }}
-                <span class="ml-1 text-lg font-normal text-gray-400">
-                  / {{ totalPublishedQuestions }}
-                </span>
-              </dd>
-            </div>
-          </dl>
-        </template>
-
-        <div class="mt-6 flex justify-end">
-          <UiButton variant="secondary" @click="closeWinnerModal">
-            {{ t('close') }}
+          </UiButton>
+          <UiButton
+            :aria-pressed="isOver9000Mode"
+            :disabled="isLoading || leaderboard.length === 0"
+            size="small"
+            :variant="isOver9000Mode ? 'primary' : 'secondary'"
+            @click="toggleOver9000Mode"
+          >
+            {{ isOver9000Mode ? t('showScores') : t('over9000') }}
+          </UiButton>
+          <UiButton
+            :disabled="isLoading"
+            size="small"
+            variant="secondary"
+            @click="fetchLeaderboard"
+          >
+            {{ t('refresh') }}
           </UiButton>
         </div>
       </div>
-    </dialog>
+
+      <UiSection :bare="isCoreView">
+        <p v-if="isLoading" class="status-message">
+          {{ t('loading') }}
+        </p>
+
+        <p
+          v-else-if="hasError"
+          class="status-message"
+        >
+          {{ t('error') }}
+        </p>
+
+        <p
+          v-else-if="leaderboard.length === 0"
+          class="status-message"
+        >
+          {{ t('empty') }}
+        </p>
+
+        <table v-else :class="isCoreView ? 'w-full border-collapse bg-white' : 'w-full border-collapse'">
+          <thead>
+            <tr
+              :class="isCoreView
+                ? 'border-b-[3px] border-black bg-black text-left tracking-wide text-white uppercase'
+                : 'border-b-[3px] border-black text-left tracking-wide uppercase'"
+            >
+              <th :class="isCoreView ? 'p-5 text-center text-3xl' : 'p-3 text-center'">
+                {{ t('rank') }}
+              </th>
+              <th :class="isCoreView ? 'p-5 text-3xl' : 'p-3'">
+                {{ t('player') }}
+              </th>
+              <th :class="isCoreView ? 'p-5 text-center text-3xl' : 'p-3 text-center'">
+                {{ t('correctAnswers') }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="entry in leaderboard"
+              :key="entry.userId"
+              :class="isCoreView
+                ? [
+                  'border-b border-black',
+                  { 'bg-black text-white': entry.rank === 1 },
+                ]
+                : 'border-b border-gray-300'"
+            >
+              <td :class="isCoreView ? 'p-5 text-center text-5xl font-bold' : 'p-3 text-center text-xl font-bold'">
+                {{ entry.rank }}
+              </td>
+              <td :class="isCoreView ? 'p-5 text-4xl font-bold' : 'p-3'">
+                {{ entry.nickname }}
+                <span
+                  v-if="showUserId"
+                  :class="isCoreView ? 'ml-2 text-lg font-normal opacity-70' : 'ml-1 text-xs text-gray-400'"
+                >
+                  ({{ entry.userId }})
+                </span>
+              </td>
+              <td :class="isCoreView ? 'p-5 text-center text-5xl font-bold' : 'p-3 text-center text-xl font-bold'">
+                {{ isOver9000Mode ? '>9000' : entry.correctAnswers }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </UiSection>
+
+      <dialog
+        v-if="isWinnerModalOpen"
+        ref="winnerDialog"
+        :aria-busy="winnerModalPhase === 'drawing'"
+        :aria-describedby="winnerModalPhase === 'ready' ? 'winner-modal-description' : undefined"
+        aria-labelledby="winner-modal-title"
+        class="m-auto max-h-[calc(100dvh-2.5rem)] w-[calc(100%-2.5rem)] max-w-md
+        border-[3px] border-black bg-white p-6 text-black backdrop:bg-black/50"
+        @click.self="closeWinnerModal"
+        @close="resetWinnerModal"
+      >
+        <canvas
+          ref="winnerConfettiCanvas"
+          aria-hidden="true"
+          class="pointer-events-none fixed inset-0 z-10 h-dvh w-dvw"
+        />
+
+        <div class="relative z-20">
+          <p class="text-sm font-bold tracking-wide uppercase">
+            {{ t('winner') }}
+          </p>
+
+          <template v-if="winnerModalPhase === 'ready'">
+            <h2 id="winner-modal-title" class="mt-2 text-4xl leading-tight font-bold">
+              {{ t('drawWinner') }}
+            </h2>
+
+            <div class="mt-6">
+              <UiButton @click="startWinnerDraw">
+                {{ t('drawWinner') }}
+              </UiButton>
+              <p id="winner-modal-description" class="mt-3 text-sm text-gray-600">
+                {{ t('winnerDrawHint') }}
+              </p>
+            </div>
+          </template>
+
+          <template v-else-if="winnerModalPhase === 'drawing'">
+            <h2 id="winner-modal-title" class="mt-2 text-4xl leading-tight font-bold">
+              {{ t('drawingWinner') }}
+            </h2>
+
+            <div aria-live="polite" class="mt-6 border-[3px] border-black bg-gray-100 p-8 text-center" role="status">
+              <div
+                aria-hidden="true"
+                class="mx-auto size-16 animate-spin border-[6px] border-black border-t-gray-300
+                motion-reduce:animate-none"
+              />
+              <p class="mt-4 text-sm font-bold tracking-wide uppercase">
+                {{ t('drawingWinner') }}
+              </p>
+            </div>
+          </template>
+
+          <template v-else-if="selectedWinner">
+            <h2 id="winner-modal-title" class="mt-2 text-4xl leading-tight font-bold">
+              {{ selectedWinner.nickname }}
+            </h2>
+
+            <dl class="mt-6 grid grid-cols-2 gap-3">
+              <div class="winner-stat">
+                <dt class="winner-stat-label">
+                  {{ t('rank') }}
+                </dt>
+                <dd class="winner-stat-value">
+                  {{ selectedWinner.rank }}
+                </dd>
+              </div>
+              <div class="winner-stat">
+                <dt class="winner-stat-label">
+                  {{ t('correctAnswers') }}
+                </dt>
+                <dd class="winner-stat-value">
+                  {{ selectedWinner.correctAnswers }}
+                  <span class="ml-1 text-lg font-normal text-gray-400">
+                    / {{ selectedWinnerTotalPublishedQuestions }}
+                  </span>
+                </dd>
+              </div>
+            </dl>
+          </template>
+
+          <div class="mt-6 flex justify-end">
+            <UiButton variant="secondary" @click="closeWinnerModal">
+              {{ t('close') }}
+            </UiButton>
+          </div>
+        </div>
+      </dialog>
+    </div>
   </div>
 </template>
 

--- a/app/pages/admin/results.vue
+++ b/app/pages/admin/results.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useDisplayParameters } from '~/composables/useDisplayParameters'
 import type { Results } from '~/types'
 
 definePageMeta({
@@ -21,11 +22,10 @@ function getLocalizedOption(enKey: string): string {
 }
 
 const route = useRoute()
-const isCoreView = computed(() => route.query.core !== undefined)
-
-// State for core view parameters
-const padding = ref(route.query.padding ? Number(route.query.padding) : 0)
-const scale = ref(route.query.scale ? Number(route.query.scale) : 1)
+const {
+  coreViewStyles,
+  isCoreView,
+} = useDisplayParameters()
 
 const visibility = ref(
   (route.query.visibility as string) || 'hide',
@@ -42,19 +42,6 @@ const isTogglingLock = ref(false)
 const isPickingUser = ref(false)
 const isResettingAnswers = ref(false)
 const hasHydratedOnce = ref(false)
-
-// Dynamic styles for core view
-const coreViewStyles = computed(() => {
-  if (!isCoreView.value) {
-    return {}
-  }
-  return {
-    'padding': `${padding.value}px`,
-    'transform': `scale(${scale.value})`,
-    'transform-origin': 'top left',
-    'width': `calc(100% / ${scale.value})`,
-  }
-})
 
 // Fetch initial results
 const { data: fetchedResults, refresh: refreshResults } = await useFetch<Results>('/api/results/current')

--- a/docs/url-parameters.md
+++ b/docs/url-parameters.md
@@ -78,9 +78,15 @@ Core view with 30px padding, 120% scale, and hidden results.
 
 ### `transparency`
 
-- **Type**: Number (decimal, clamped to max 1)
+- **Type**: Number (decimal, clamped to `0`–`1`)
 - **Default**: `1`
-- **Effect**: Sets emoji opacity. Values are clamped to maximum 1.0 (fully opaque).
+- **Effect**: Sets emoji opacity. Values are clamped from `0` (transparent) to `1` (fully opaque).
+
+### `background`
+
+- **Type**: Hex color (`#RRGGBB`)
+- **Default**: Not set (transparent)
+- **Effect**: Fills the emoji display viewport with the supplied color. Invalid values leave the transparent background unchanged.
 
 ### Examples
 
@@ -96,4 +102,61 @@ Emojis rendered at 50% opacity.
 
 /admin/emojis?scale=1.5&transparency=0.7
 Emojis at 150% size with 70% opacity.
+
+/admin/emojis?background=%23000000
+Emojis on a black background. Encode the `#` character as `%23` in URLs.
 ```
+
+## `/admin/leaderboard` Page
+
+### `core`
+
+- **Type**: Flag (presence check)
+- **Default**: Not set
+- **Effect**: Uses a projector-oriented table with large rank and score text. Winner draw, score masking, and manual refresh controls remain available.
+
+### `padding`
+
+- **Type**: Non-negative number (pixels)
+- **Default**: `0`
+- **Effect**: Adds padding around the leaderboard content in core view mode.
+
+### `scale`
+
+- **Type**: Positive number (decimal)
+- **Default**: `1`
+- **Effect**: Scales leaderboard content in core view mode.
+
+### `background`
+
+- **Type**: Hex color (`#RRGGBB`)
+- **Default**: Not set (the existing leaderboard grid background)
+- **Effect**: Replaces the leaderboard page background with the supplied color. Invalid values preserve the existing background.
+
+### `showUserId`
+
+- **Type**: Boolean (`true` | `false`)
+- **Default**: `true`
+- **Effect**: Shows technical participant IDs by default. Set to `false` for display surfaces that should show only nicknames, ranks, and scores.
+
+### `refresh`
+
+- **Type**: Non-negative integer (seconds)
+- **Default**: `5`
+- **Effect**: Fetches only leaderboard data at the selected interval without reloading the page. Set to `0` to disable automatic refresh. Invalid or negative values use the five-second default.
+- **Winner dialog**: An open draw or revealed-winner dialog is not closed or replaced by a refresh. The draw candidates and revealed winner remain fixed until the dialog is closed, even if the refreshed table no longer contains that winner.
+
+### Examples
+
+```text
+/admin/leaderboard
+Standard leaderboard with five-second data refresh and visible participant IDs.
+
+/admin/leaderboard?core&padding=20&scale=0.9&background=%23ffffff&showUserId=false&refresh=10
+Projector-oriented leaderboard with a white background, hidden technical IDs, and a ten-second data refresh interval.
+
+/admin/leaderboard?refresh=0
+Standard leaderboard with manual refresh only.
+```
+
+For `background`, encode the `#` character as `%23` in URLs.

--- a/docs/url-parameters.md
+++ b/docs/url-parameters.md
@@ -137,7 +137,7 @@ Emojis on a black background. Encode the `#` character as `%23` in URLs.
 
 - **Type**: Boolean (`true` | `false`)
 - **Default**: `true`
-- **Effect**: Shows technical participant IDs by default. Set to `false` for display surfaces that should show only nicknames, ranks, and scores.
+- **Effect**: Sets the initial visibility of technical participant IDs. IDs are visible by default; set to `false` for display surfaces that should show only nicknames, ranks, and scores. The leaderboard control can change this visibility after loading.
 
 ### `refresh`
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -86,6 +86,7 @@ export default defineNuxtConfig({
     clientBundle: {
       icons: [
         'ph:arrow-down',
+        'ph:arrow-clockwise',
         'ph:arrow-up',
         'ph:eye',
         'ph:eye-slash',


### PR DESCRIPTION
This PR adds shared display URL parameters, configurable emoji backgrounds, and a projector-oriented leaderboard with participant-ID controls and automatic polling. It preserves leaderboard data across refresh failures, applies safe numeric defaults and transparency bounds, adds focused coverage, and documents the supported display URLs.

**feat**

- Add shared reactive parsing for `background`, `core`, `padding`, `scale`, `transparency`, `showUserId`, and `refresh` display parameters.
- Add a projector-oriented leaderboard layout, automatic data polling, participant-ID visibility controls, a bundled refresh icon, and winner-state preservation across refreshes.
- Add configurable emoji backgrounds and reuse shared scale and transparency parsing in emoji and results pages.

**fix**

- Treat blank numeric display parameters as missing and clamp transparency to the documented `0`–`1` range.
- Keep the last successful leaderboard visible during pending or failed background refreshes.

**test**

- Add composable and rendered-page coverage for display parsing, blank defaults, transparency bounds, emoji backgrounds, leaderboard controls, polling failures, and winner-state preservation.

**docs**

- Document emoji background and leaderboard display parameters, defaults, behavior, and URL examples.