### PR TITLE
feat: add configurable API CORS policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,15 @@ NUXT_ADMIN_PASSWORD=123
 # Leave empty to disable this auth path. Only one exact token is accepted.
 NUXT_ADMIN_TOKEN=
 
+# Enable CORS for separately hosted browser clients that call `/api/*`.
+# Default from nuxt.config.ts: false. CORS uses bearer headers, never cookies.
+NUXT_API_CORS_ENABLED=false
+
+# Comma-separated exact HTTP(S) origins allowed to call `/api/*` when CORS is
+# enabled. Wildcards, paths, query parameters, fragments, and credentials are
+# rejected. Example: http://localhost:3030,https://slides.example
+NUXT_API_CORS_ALLOWED_ORIGINS=
+
 # Delay in milliseconds before the server flushes a queued emoji batch.
 # Must be a positive integer.
 # Default from nuxt.config.ts: 150

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,12 @@ services:
     image: stage-flow-tools
     container_name: stage-flow-tools
     restart: unless-stopped
-    # Choose one and uncomment:
+    environment:
+      NUXT_API_CORS_ALLOWED_ORIGINS: "${NUXT_API_CORS_ALLOWED_ORIGINS:-}"
+      NUXT_API_CORS_ENABLED: "${NUXT_API_CORS_ENABLED:-false}"
+    # Add other runtime configuration with one of these options:
     # env_file:
     #   - .env
-    # environment:
-    #   - NUXT_JWT_SECRET=...
-    #   - ...
     volumes:
       - ./.data:/app/.data
     networks:
@@ -26,8 +26,3 @@ services:
       - traefik.http.routers.stage-flow-tools.rule=Host(`quiz.your-domain.com`)
       - traefik.http.routers.stage-flow-tools.entrypoints=websecure
       - traefik.http.routers.stage-flow-tools.tls.certresolver=myresolver
-      - traefik.http.middlewares.stage-flow-tools-cors.headers.accesscontrolalloworiginlist=http://localhost:3030
-      - traefik.http.middlewares.stage-flow-tools-cors.headers.accesscontrolallowmethods=GET,POST,OPTIONS
-      - traefik.http.middlewares.stage-flow-tools-cors.headers.accesscontrolallowheaders=Authorization,Content-Type
-      - traefik.http.middlewares.stage-flow-tools-cors.headers.addvaryheader=true
-      - traefik.http.routers.stage-flow-tools.middlewares=stage-flow-tools-cors

--- a/docs/deployment-docker.md
+++ b/docs/deployment-docker.md
@@ -54,6 +54,20 @@ NUXT_JWT_SECRET=<paste-output-from-openssl>
 
 Set `NUXT_ADMIN_TOKEN` only if external software needs either direct admin API access with `Authorization: Bearer <token>` or protected admin page access with `?token=<token>`. Leave it empty to disable that path. Only one exact token is accepted.
 
+### CORS for Slidev and other browser clients
+
+Cross-origin REST API access is disabled by default. Enable it only for the exact origins that need it. For a local Slidev presentation running on port `3030`:
+
+```bash
+# In .env:
+NUXT_API_CORS_ENABLED=true
+NUXT_API_CORS_ALLOWED_ORIGINS=http://localhost:3030
+```
+
+Use a comma-separated list for multiple origins, for example `http://localhost:3030,https://slides.example`. Entries must be exact `http` or `https` origins without wildcards, paths, query parameters, fragments, or credentials.
+
+This policy applies only to `/api/*`, allows `GET`, `POST`, and `OPTIONS`, and accepts `Authorization` and `Content-Type` request headers. It deliberately does not enable cross-origin cookies. Browser clients calling protected presenter endpoints must send `Authorization: Bearer <token>` and must not embed that token in publicly distributed slide assets. The application now sends these headers itself; no Traefik CORS middleware is needed.
+
 Admin authentication variants:
 
 1. `/login` with `NUXT_ADMIN_USERNAME` and `NUXT_ADMIN_PASSWORD` for normal human admin access.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -25,6 +25,8 @@ const configBase: InputConfig<NuxtConfig, ConfigLayerMeta> = {
     adminPassword: '123',
     adminToken: '',
     adminUsername: 'admin',
+    apiCorsAllowedOrigins: '',
+    apiCorsEnabled: false,
     drizzleStudioInternalPort: '64983',
     emojiBatchMaxSize: 1200,
     emojiBatchTickMs: 150,

--- a/server/middleware/api-cors.ts
+++ b/server/middleware/api-cors.ts
@@ -1,0 +1,7 @@
+import { handleApiCors } from '../utils/api-cors'
+
+export default defineEventHandler((event) => {
+  if (handleApiCors(event, useRuntimeConfig(event))) {
+    return
+  }
+})

--- a/server/plugins/api-cors.ts
+++ b/server/plugins/api-cors.ts
@@ -1,0 +1,8 @@
+import { defineNitroPlugin } from 'nitropack/runtime'
+
+import { validateApiCorsConfig } from '../utils/api-cors'
+
+/** Validates API CORS settings before the server accepts requests. */
+export default defineNitroPlugin(() => {
+  validateApiCorsConfig(useRuntimeConfig())
+})

--- a/server/utils/api-cors.test.ts
+++ b/server/utils/api-cors.test.ts
@@ -1,0 +1,165 @@
+import {
+  createApp,
+  eventHandler,
+  toWebHandler,
+} from 'h3'
+import {
+  describe,
+  expect,
+  it,
+} from 'vite-plus/test'
+
+import {
+  getApiCorsOptions,
+  handleApiCors,
+  validateApiCorsConfig,
+} from './api-cors'
+
+const enabledConfig = {
+  apiCorsAllowedOrigins: 'http://localhost:3030,https://slides.example',
+  apiCorsEnabled: true,
+}
+
+async function requestApi(
+  config: typeof enabledConfig,
+  path: string,
+  init: RequestInit,
+) {
+  let routeCalled = false
+  const app = createApp()
+
+  app.use(eventHandler((event) => {
+    if (handleApiCors(event, config)) {
+      return
+    }
+
+    routeCalled = true
+
+    return { success: true }
+  }))
+
+  const response = await toWebHandler(app)(new Request(`https://quiz.example${path}`, init))
+
+  return {
+    response,
+    routeCalled,
+  }
+}
+
+describe('API CORS configuration', () => {
+  it('stays disabled by default', () => {
+    expect(getApiCorsOptions({
+      apiCorsAllowedOrigins: '',
+      apiCorsEnabled: false,
+    })).toBeUndefined()
+  })
+
+  it('uses each configured HTTP(S) origin once', () => {
+    expect(getApiCorsOptions({
+      apiCorsAllowedOrigins: 'http://localhost:3030, https://slides.example, http://localhost:3030',
+      apiCorsEnabled: 'true',
+    })).toEqual({
+      allowHeaders: [
+        'Authorization',
+        'Content-Type',
+      ],
+      credentials: false,
+      methods: [
+        'GET',
+        'POST',
+        'OPTIONS',
+      ],
+      origin: [
+        'http://localhost:3030',
+        'https://slides.example',
+      ],
+    })
+  })
+
+  it.each([
+    '',
+    '*',
+    'https://*.example',
+    'https://slides.example/path',
+    'https://slides.example?preview=true',
+    'https://user:password@slides.example',
+    'ftp://slides.example',
+  ])('rejects unsafe allowed origin %s', (apiCorsAllowedOrigins) => {
+    expect(() => validateApiCorsConfig({
+      apiCorsAllowedOrigins,
+      apiCorsEnabled: true,
+    })).toThrowError(/Invalid runtime config apiCorsAllowedOrigins/)
+  })
+
+  it.each([
+    'enabled',
+    1,
+    null,
+  ])('rejects invalid enabled value %s', (apiCorsEnabled) => {
+    expect(() => validateApiCorsConfig({
+      apiCorsAllowedOrigins: 'http://localhost:3030',
+      apiCorsEnabled,
+    })).toThrowError('Invalid runtime config apiCorsEnabled: expected true or false.')
+  })
+})
+
+describe('API CORS middleware', () => {
+  it('allows an exact configured origin on API responses without cookie credentials', async () => {
+    const { response, routeCalled } = await requestApi(enabledConfig, '/api/questions/active', {
+      headers: { origin: 'http://localhost:3030' },
+    })
+
+    expect(routeCalled).toBe(true)
+    expect(response.headers.get('access-control-allow-origin')).toBe('http://localhost:3030')
+    expect(response.headers.get('access-control-allow-credentials')).toBeNull()
+    expect(response.headers.get('vary')).toContain('origin')
+  })
+
+  it('ends allowed API preflights before their route handler', async () => {
+    const { response, routeCalled } = await requestApi(enabledConfig, '/api/admin/presenter/current-state', {
+      headers: {
+        'access-control-request-headers': 'authorization,content-type',
+        'access-control-request-method': 'GET',
+        origin: 'http://localhost:3030',
+      },
+      method: 'OPTIONS',
+    })
+
+    expect(routeCalled).toBe(false)
+    expect(response.status).toBe(204)
+    expect(response.headers.get('access-control-allow-origin')).toBe('http://localhost:3030')
+    expect(response.headers.get('access-control-allow-methods')).toBe('GET,POST,OPTIONS')
+    expect(response.headers.get('access-control-allow-headers')).toBe('Authorization,Content-Type')
+    expect(response.headers.get('access-control-allow-credentials')).toBeNull()
+  })
+
+  it('does not grant CORS to unconfigured origins', async () => {
+    const { response, routeCalled } = await requestApi(enabledConfig, '/api/questions/active', {
+      headers: { origin: 'https://untrusted.example' },
+    })
+
+    expect(routeCalled).toBe(true)
+    expect(response.headers.get('access-control-allow-origin')).toBeNull()
+  })
+
+  it('leaves API requests unchanged when CORS is disabled', async () => {
+    const { response, routeCalled } = await requestApi({
+      apiCorsAllowedOrigins: 'http://localhost:3030',
+      apiCorsEnabled: false,
+    }, '/api/questions/active', {
+      headers: { origin: 'http://localhost:3030' },
+    })
+
+    expect(routeCalled).toBe(true)
+    expect(response.headers.get('access-control-allow-origin')).toBeNull()
+  })
+
+  it('does not apply CORS outside API routes', async () => {
+    const { response, routeCalled } = await requestApi(enabledConfig, '/_ws/default', {
+      headers: { origin: 'http://localhost:3030' },
+    })
+
+    expect(routeCalled).toBe(true)
+    expect(response.headers.get('access-control-allow-origin')).toBeNull()
+  })
+})

--- a/server/utils/api-cors.ts
+++ b/server/utils/api-cors.ts
@@ -1,0 +1,126 @@
+import {
+  getRequestHeader,
+  handleCors,
+} from 'h3'
+import type {
+  H3CorsOptions,
+  H3Event,
+} from 'h3'
+
+type ApiCorsRuntimeConfig = {
+  apiCorsAllowedOrigins: unknown
+  apiCorsEnabled: unknown
+}
+
+type ApiCorsOptions = H3CorsOptions
+
+const apiCorsMethods = [
+  'GET',
+  'POST',
+  'OPTIONS',
+]
+
+const apiCorsAllowedHeaders = [
+  'Authorization',
+  'Content-Type',
+]
+
+const invalidAllowedOriginsMessage = [
+  'Invalid runtime config apiCorsAllowedOrigins:',
+  'expected comma-separated absolute HTTP(S) origins without wildcards,',
+  'paths, query parameters, fragments, or credentials.',
+].join(' ')
+
+function requireBoolean(value: unknown, key: string): boolean {
+  if (value === true || value === 'true') {
+    return true
+  }
+
+  if (value === false || value === 'false') {
+    return false
+  }
+
+  throw new Error(`Invalid runtime config ${key}: expected true or false.`)
+}
+
+function invalidAllowedOrigins(): never {
+  throw new Error(invalidAllowedOriginsMessage)
+}
+
+function parseAllowedOrigins(value: unknown): string[] {
+  if (typeof value !== 'string') {
+    invalidAllowedOrigins()
+  }
+
+  if (!value) {
+    return []
+  }
+
+  const origins = new Set<string>()
+
+  for (const configuredOrigin of value.split(',')) {
+    const origin = configuredOrigin.trim()
+
+    if (!origin || origin.includes('*')) {
+      invalidAllowedOrigins()
+    }
+
+    try {
+      const url = new URL(origin)
+
+      if (
+        (url.protocol !== 'http:' && url.protocol !== 'https:')
+        || origin !== url.origin
+      ) {
+        invalidAllowedOrigins()
+      }
+
+      origins.add(url.origin)
+    }
+    catch {
+      invalidAllowedOrigins()
+    }
+  }
+
+  return [
+    ...origins,
+  ]
+}
+
+/** Resolves the optional server-side CORS policy for separately hosted API clients. */
+export function getApiCorsOptions(config: ApiCorsRuntimeConfig): ApiCorsOptions | undefined {
+  if (!requireBoolean(config.apiCorsEnabled, 'apiCorsEnabled')) {
+    return undefined
+  }
+
+  const origins = parseAllowedOrigins(config.apiCorsAllowedOrigins)
+
+  if (origins.length === 0) {
+    throw new Error(
+      'Invalid runtime config apiCorsAllowedOrigins: expected at least one origin when apiCorsEnabled is true.',
+    )
+  }
+
+  return {
+    allowHeaders: apiCorsAllowedHeaders,
+    credentials: false,
+    methods: apiCorsMethods as ApiCorsOptions['methods'],
+    origin: origins,
+  }
+}
+
+/** Fails startup when the configured CORS policy is ambiguous or unsafe. */
+export function validateApiCorsConfig(config: ApiCorsRuntimeConfig): void {
+  getApiCorsOptions(config)
+}
+
+/** Appends API-only CORS headers and returns whether it completed a preflight request. */
+export function handleApiCors(event: H3Event, config: ApiCorsRuntimeConfig): boolean {
+  if (!event.path.startsWith('/api/') || !getRequestHeader(event, 'origin')) {
+    return false
+  }
+
+  const options = getApiCorsOptions(config)
+
+  return options ? handleCors(event, options) : false
+}


### PR DESCRIPTION
⚠️ **API CORS configuration required:** Deployments that relied on the removed Traefik CORS middleware must set NUXT_API_CORS_ENABLED=true and NUXT_API_CORS_ALLOWED_ORIGINS to the exact presenter origins before upgrading; otherwise cross-origin Slidev REST calls will stop working.

This PR adds opt-in, exact-origin CORS handling for `/api/*`, including startup validation and bearer-only preflight behavior. It forwards the runtime settings through Docker Compose, removes the overlapping Traefik CORS middleware, and documents the Slidev setup. It adds response-level tests for configuration, allowed and rejected origins, disabled mode, preflights, and non-API routes.

**feat**

- Adds a server-owned, API-only CORS policy that is disabled by default and permits exact configured origins without cookie credentials.
- Validates CORS settings at Nitro startup and completes allowed preflight requests before API route handlers run.

**test**

- Covers configuration parsing, allowed and rejected origins, disabled mode, preflight responses, and non-API routes.

**docs**

- Documents the CORS environment contract and bearer-token setup for Slidev and other browser clients.

**chore**

- Forwards CORS runtime values through Docker Compose and removes the competing Traefik CORS middleware labels.